### PR TITLE
Parse roles and relationships when reading a Document

### DIFF
--- a/sbol/document.py
+++ b/sbol/document.py
@@ -497,8 +497,8 @@ class Document(Identified):
         if found != -1:
             # property_ns, property_name = property_uri.split[:found]  # <-- this line didn't appear to have any purpose
             # Checks if the object's property already exists
-            if subject in self.SBOLObjects:
-                parent = self.SBOLObjects[subject]
+            if str(subject) in self.SBOLObjects:
+                parent = self.SBOLObjects[str(subject)]
                 # Decide if this triple corresponds to a simple property,
                 # a list property, an owned property or a referenced property
                 if predicate in parent.properties:
@@ -506,7 +506,7 @@ class Document(Identified):
                     parent.properties[predicate].append(obj)
                 elif predicate in parent.owned_objects:
                     # triple is an owned object
-                    owned_obj = self.SBOLObjects[obj]
+                    owned_obj = self.SBOLObjects[str(obj)]
                     if owned_obj is not None:
                         parent.owned_objects[predicate].append(owned_obj)
                         owned_obj.parent = parent

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -360,7 +360,7 @@ class SBOLObject:
         for typeURI, objlist in self.owned_objects.items():
             for owned_obj in objlist:
                 graph.add((self._identity.getRawValue(),
-                           typeURI, owned_obj.identity))
+                           typeURI, URIRef(owned_obj.identity)))
                 owned_obj.build_graph(graph)
 
     def serialize_rdf2xml(self, graph):

--- a/sbol/test/test_property.py
+++ b/sbol/test/test_property.py
@@ -48,6 +48,17 @@ class TestProperty(unittest.TestCase):
         self.assertEqual('http://sbols.org/CRISPR_Example/CRa_U6_seq/1.0.0',
                          str(s1))
 
+    def test_readProperties(self):
+        d = Document()
+        d.read(TEST_LOCATION)
+        cd2 = d.componentDefinitions['http://sbols.org/CRISPR_Example/EYFP_gene/1.0.0']
+        self.assertEqual(2, len(cd2.components))
+        self.assertEqual(1, len(cd2.roles))
+        md = d.moduleDefinitions['http://sbols.org/CRISPR_Example/CRISPR_Template/1.0.0']
+        self.assertEqual(5, len(md.functionalComponents))
+        self.assertEqual(3, len(md.interactions))
+        self.assertEqual(0, len(md.roles))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a unit test to ensure roles and relationships are properly parsed. And parsed the roles and relationships.

Fixes #3 