### PR TITLE
Handle utf-8 in Document.append

### DIFF
--- a/sbol/document.py
+++ b/sbol/document.py
@@ -494,7 +494,6 @@ class Document(Identified):
         if found == -1:
             found = predicate.rfind('/')
         if found != -1:
-            # property_ns, property_name = property_uri.split[:found]  # <-- this line didn't appear to have any purpose
             # Checks if the object's property already exists
             if str(subject) in self.SBOLObjects:
                 parent = self.SBOLObjects[str(subject)]

--- a/sbol/document.py
+++ b/sbol/document.py
@@ -372,18 +372,17 @@ class Document(Identified):
         :return: None
         """
         self.logger.debug("Appending data from file: " + filename)
-        with open(filename, 'r') as f:
-            if not self.graph:
-                self.graph = rdflib.Graph()
-            # Save any changes we've made to the graph.
-            self.update_graph()
-            # Use rdflib to automatically merge the graphs together
-            self.graph.parse(f, format="application/rdf+xml")
-            # Clean up our internal data structures.
-            # (There's probably a more efficient way to merge.)
-            self.clear(clear_graph=False)
-            # Base our internal representation on the new graph.
-            self.parse_all()
+        if not self.graph:
+            self.graph = rdflib.Graph()
+        # Save any changes we've made to the graph.
+        self.update_graph()
+        # Use rdflib to automatically merge the graphs together
+        self.graph.parse(filename, format="application/rdf+xml")
+        # Clean up our internal data structures.
+        # (There's probably a more efficient way to merge.)
+        self.clear(clear_graph=False)
+        # Base our internal representation on the new graph.
+        self.parse_all()
 
     def parse_all(self):
         # Parse namespaces

--- a/sbol/test/test_document.py
+++ b/sbol/test/test_document.py
@@ -1,9 +1,9 @@
+import locale
+import os
 import unittest
+# Needed for setHomespace and maybe Config and some other things
 from sbol.document import *
-from sbol.moduledefinition import *
-from sbol.componentdefinition import *
-from sbol.constants import *
-
+import sbol
 
 MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
 TEST_LOCATION = os.path.join(MODULE_LOCATION, 'resources', 'crispr_example.xml')
@@ -12,12 +12,12 @@ TEST_LOCATION = os.path.join(MODULE_LOCATION, 'resources', 'crispr_example.xml')
 class TestDocument(unittest.TestCase):
 
     def test_empty_len0(self):
-        doc = Document()
+        doc = sbol.Document()
         # print(doc)
         self.assertEqual(0, len(doc), "Length of document should be 0")
 
     def test_addGetTopLevel_uri(self):
-        doc = Document()
+        doc = sbol.Document()
         # Tutorial doesn't drop final forward slash, but this isn't right.
         setHomespace('http://sbols.org/CRISPR_Example')
         Config.setOption('sbol_compliant_uris', True)
@@ -34,7 +34,7 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(cas9, cas9_2)
 
     def test_addGetTopLevel_displayId(self):
-        doc = Document()
+        doc = sbol.Document()
         setHomespace('http://sbols.org/CRISPR_Example')
         Config.setOption('sbol_compliant_uris', True)
         Config.setOption('sbol_typed_uris', False)
@@ -49,7 +49,7 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(cas9, cas9_2)
 
     def test_addGetTopLevel_indexing(self):
-        doc = Document()
+        doc = sbol.Document()
         # Tutorial doesn't drop final forward slash, but this isn't right.
         setHomespace('http://sbols.org/CRISPR_Example')
         Config.setOption('sbol_compliant_uris', True)
@@ -65,22 +65,60 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(cas9, cas9_2)
 
     def test_iteration(self):
-        doc = Document()
+        doc = sbol.Document()
         doc.read(TEST_LOCATION)
         i = 0
         for obj in doc:
             i += 1
-            print(obj)
+            # print(obj)
         self.assertEqual(len(doc), 31)
         # print(doc)
 
     def test_identity(self):
         # The sbol:identity relation should not be written out when
         # serializing SBOL.
-        doc = Document()
+        doc = sbol.Document()
         doc.read(TEST_LOCATION)
         result = doc.writeString()
         self.assertNotIn('sbol:identity', result)
+
+    def test_utf8_append(self):
+        utf8_path = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL2', 'pICSL50014.xml')
+        doc = sbol.Document()
+        doc.append(utf8_path)
+
+    def test_utf8_append_no_locale(self):
+        # Test loading a utf-8 SBOL file without LANG set. This was a
+        # bug at one time, and only shows itself when LANG is unset.
+        # Here we simulate that by temporarily setting the locale to
+        # the generic 'C' locale.
+        utf8_path = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL2', 'pICSL50014.xml')
+        loc = locale.getlocale()
+        try:
+            locale.setlocale(locale.LC_ALL, 'C')
+            doc = sbol.Document()
+            doc.append(utf8_path)
+        finally:
+            locale.setlocale(locale.LC_ALL, loc)
+
+    def test_utf8_read(self):
+        utf8_path = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL2', 'pICSL50014.xml')
+        doc = sbol.Document()
+        doc.read(utf8_path)
+
+    def test_utf8_read_no_locale(self):
+        # Test loading a utf-8 SBOL file without LANG set. This was a
+        # bug at one time, and only shows itself when LANG is unset.
+        # Here we simulate that by temporarily setting the locale to
+        # the generic 'C' locale.
+        utf8_path = os.path.join(MODULE_LOCATION, 'SBOLTestSuite', 'SBOL2', 'pICSL50014.xml')
+        loc = locale.getlocale()
+        try:
+            locale.setlocale(locale.LC_ALL, 'C')
+            doc = sbol.Document()
+            doc.read(utf8_path)
+        finally:
+            locale.setlocale(locale.LC_ALL, loc)
 
 
 if __name__ == '__main__':

--- a/sbol/test/test_roundtrip.py
+++ b/sbol/test/test_roundtrip.py
@@ -80,10 +80,6 @@ class TestRoundTripSBOL2(unittest.TestCase):
     def test_sbol2_files(self):
         subtest = 1
         for f in TEST_FILES_SBOL2:
-            if os.path.basename(f) == 'pICSL50014.xml':
-                # This one is UTF-8. Skip it here, and test it below
-                # in a controlled environment.
-                continue
             if os.path.basename(f) == 'test_source_location.xml':
                 # This one has an error. Temporarily give it its own
                 # test and expect the failure.
@@ -97,7 +93,6 @@ class TestRoundTripSBOL2(unittest.TestCase):
     def test_source_location(self):
         self.run_round_trip(os.path.join(TEST_LOC_SBOL2, 'test_source_location.xml'))
 
-    @unittest.expectedFailure
     def test_utf8_roundtrip(self):
         # Test loading a utf-8 SBOL file without LANG set. This was a
         # bug at one time, and only shows itself when LANG is unset.

--- a/sbol/test/test_roundtrip.py
+++ b/sbol/test/test_roundtrip.py
@@ -91,7 +91,7 @@ class TestRoundTripSBOL2(unittest.TestCase):
 
     @unittest.expectedFailure
     def test_source_location(self):
-        self.run_round_trip(os.path.join(TEST_LOC_SBOL2, 'test_source_location.xml'))
+        self.run_round_trip('test_source_location.xml')
 
     def test_utf8_roundtrip(self):
         # Test loading a utf-8 SBOL file without LANG set. This was a
@@ -101,7 +101,7 @@ class TestRoundTripSBOL2(unittest.TestCase):
         loc = locale.getlocale()
         try:
             locale.setlocale(locale.LC_ALL, 'C')
-            self.run_round_trip(os.path.join(TEST_LOC_SBOL2, 'pICSL50014.xml'))
+            self.run_round_trip('pICSL50014.xml')
         finally:
             locale.setlocale(locale.LC_ALL, loc)
 


### PR DESCRIPTION
Teach Document how to load utf-8 encoded SBOL files regardless of locale settings. Add unit tests for successful loading regardless of locale setting. Change round trip testing to no longer expect failure when loading a utf-8 encoded SBOL file.

Fixes #17 