### PR TITLE
Fix Document.find()

### DIFF
--- a/sbol/document.py
+++ b/sbol/document.py
@@ -731,7 +731,7 @@ class Document(Identified):
         :return: A pointer to the SBOLObject,
         or NULL if an object with this identity doesn't exist.
         """
-        for obj in self.SBOLObjects:
+        for obj in self.SBOLObjects.values():
             match = obj.find(uri)
             if match is not None:
                 return match

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -14,7 +14,7 @@ class SBOLObject:
     # 'Protected' members
     _namespaces = None
     _default_namespace = None
-    _hidden_properties = None
+    _hidden_properties = []
 
     # def _init(self, rdf_type, uri):
     #     raise NotImplementedError("Not yet implemented")
@@ -206,7 +206,6 @@ class SBOLObject:
         """
         # TODO This may work differently than the original method...
         if type(comparand) != type(self):
-            self.logger.warning("TYPES ARE NOT EQUAL!!!")
             return False
         is_equal = True
         if self.rdf_type != comparand.rdf_type:

--- a/sbol/test/test_document.py
+++ b/sbol/test/test_document.py
@@ -128,6 +128,15 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(len(doc), 31)
         self.assertEqual(len(doc.componentDefinitions), 25)
 
+    def test_find(self):
+        doc = sbol.Document(TEST_LOCATION)
+        found = doc.find('http://sbols.org/CRISPR_Example/CRISPR_Template')
+        # At one point Document.find was returning -1 because it was calling str.find
+        self.assertNotEqual(found, -1)
+        self.assertIsNone(found)
+        found = doc.find('http://sbols.org/CRISPR_Example/CRISPR_Template/1.0.0')
+        self.assertNotEqual(found, -1)
+        self.assertIsNotNone(found)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Document.find() is iterating over the keys of a dict instead of the
values. This causes it to call str.find instead of SBOLObject.find,
and to return -1 instead of an SBOLObject or None. Iterate over the
values() instead, and add a unit test to prevent regression.

Fixes #26 