### PR TITLE
Implement OwnedObject.create()

### DIFF
--- a/sbol/__init__.py
+++ b/sbol/__init__.py
@@ -8,15 +8,23 @@ __version__ = '3.0.0'
 # instead of `__all__`, we will try to be careful about what gets
 # imported into this file. In the absence of __all__, all imported
 # symbols are also exported.
+from .combinatorialderivation import CombinatorialDerivation
+from .component import Component
 from .config import Config, ConfigOptions
 from .config import getHomespace, hasHomespace, setHomespace
 from .constants import *
+from .dbtl import Design
 from .document import Document
 from .componentdefinition import ComponentDefinition
+from .interaction import Interaction
+from .module import Module
 from .moduledefinition import ModuleDefinition
+from .participation import Participation
 from .partshop import PartShop
+from .provo import Activity
 from .sbolerror import SBOLError
 from .sequence import Sequence
+from .sequenceannotation import SequenceAnnotation
 
 
 def testSBOL():

--- a/sbol/combinatorialderivation.py
+++ b/sbol/combinatorialderivation.py
@@ -47,6 +47,7 @@ class CombinatorialDerivation(TopLevel):
                                                SBOL_COMBINATORIAL_DERIVATION,
                                                '0', '1', [])
         self.variableComponents = OwnedObject(self, SBOL_VARIABLE_COMPONENTS,
+                                              VariableComponent,
                                               '0', '*', [])
 
     @property

--- a/sbol/component.py
+++ b/sbol/component.py
@@ -1,6 +1,9 @@
-from .identified import Identified
-from .property import URIProperty, OwnedObject, ReferencedObject
 from .constants import *
+from .identified import Identified
+from .location import Location
+from .mapsto import MapsTo
+from .measurement import Measurement
+from .property import URIProperty, OwnedObject, ReferencedObject
 
 
 class ComponentInstance(Identified):
@@ -10,8 +13,10 @@ class ComponentInstance(Identified):
                                            SBOL_COMPONENT_DEFINITION,
                                            '1', '1', [], definition)
         self._access = URIProperty(self, SBOL_ACCESS, '0', '1', [], access)
-        self.mapsTos = OwnedObject(self, SBOL_MAPS_TOS, '0', '*', [])
-        self.measurements = OwnedObject(self, SBOL_MEASUREMENTS, '0', '*', [])
+        self.mapsTos = OwnedObject(self, SBOL_MAPS_TOS, MapsTo,
+                                   '0', '*', [])
+        self.measurements = OwnedObject(self, SBOL_MEASUREMENTS, Measurement,
+                                        '0', '*', [])
 
     @property
     def access(self):
@@ -30,7 +35,8 @@ class Component(ComponentInstance):
         self._roleIntegration = URIProperty(self, SBOL_ROLE_INTEGRATION,
                                             '0', '1', [],
                                             SBOL_ROLE_INTEGRATION_MERGE)
-        self.sourceLocations = OwnedObject(self, SBOL_LOCATIONS, '0', '*', [])
+        self.sourceLocations = OwnedObject(self, SBOL_LOCATIONS, Location,
+                                           '0', '*', [])
 
     @property
     def roles(self):

--- a/sbol/componentdefinition.py
+++ b/sbol/componentdefinition.py
@@ -1,6 +1,10 @@
+from .component import Component
 from .toplevel import *
 from . import validation
 from .property import URIProperty
+from .sequence import Sequence
+from .sequenceannotation import SequenceAnnotation
+from .sequenceconstraint import SequenceConstraint
 
 
 class ComponentDefinition(TopLevel):
@@ -112,14 +116,18 @@ class ComponentDefinition(TopLevel):
         self._roles = URIProperty(self, SBOL_ROLES,
                                   '0', '*', None)
         self.sequence = OwnedObject(self, SBOL_SEQUENCE,
+                                    Sequence,
                                     '0', '1', [validation.libsbol_rule_20])
         self.sequences = ReferencedObject(self, SBOL_SEQUENCE_PROPERTY,
                                           SBOL_SEQUENCE, '0', '*',
                                           [validation.libsbol_rule_21])
         self.sequenceAnnotations = OwnedObject(self, SBOL_SEQUENCE_ANNOTATIONS,
+                                               SequenceAnnotation,
                                                '0', '*', None)
-        self.components = OwnedObject(self, SBOL_COMPONENTS, '0', '*', None)
+        self.components = OwnedObject(self, SBOL_COMPONENTS, Component,
+                                      '0', '*', None)
         self.sequenceConstraints = OwnedObject(self, SBOL_SEQUENCE_CONSTRAINTS,
+                                               SequenceConstraint,
                                                '0', '*', None)
 
     @property

--- a/sbol/document.py
+++ b/sbol/document.py
@@ -18,7 +18,7 @@ from .provo import Plan, Activity, Agent, Usage, Association
 from .attachment import Attachment
 from .combinatorialderivation import CombinatorialDerivation
 from .implementation import Implementation
-from .dbtl import Design, Analysis, SampleRoster
+from .dbtl import Analysis, Build, Design, SampleRoster, Test
 from .experiment import Experiment, ExperimentalData
 from .object import SBOLObject
 from .property import OwnedObject, URIProperty
@@ -94,44 +94,50 @@ class Document(Identified):
         self.SBOLObjects = {}  # Needed?
         self._namespaces = {}
         self.resource_namespaces = set()
-        self.designs = OwnedObject(self, SYSBIO_DESIGN,
+        self.designs = OwnedObject(self, SYSBIO_DESIGN, Design,
                                    '0', '*', [libsbol_rule_11])
-        self.builds = OwnedObject(self, SYSBIO_BUILD,
+        self.builds = OwnedObject(self, SYSBIO_BUILD, Build,
                                   '0', '*', [libsbol_rule_12])
-        self.tests = OwnedObject(self, SYSBIO_TEST,
+        self.tests = OwnedObject(self, SYSBIO_TEST, Test,
                                  '0', '*', [libsbol_rule_13])
-        self.analyses = OwnedObject(self, SYSBIO_ANALYSIS,
+        self.analyses = OwnedObject(self, SYSBIO_ANALYSIS, Analysis,
                                     '0', '*', [libsbol_rule_14])
         self.componentDefinitions = OwnedObject(self,
                                                 SBOL_COMPONENT_DEFINITION,
+                                                ComponentDefinition,
                                                 '0', '*', None)
         self.moduleDefinitions = OwnedObject(self,
                                              SBOL_MODULE_DEFINITION,
+                                             ModuleDefinition,
                                              '0', '*', None)
-        self.models = OwnedObject(self, SBOL_MODEL,
+        self.models = OwnedObject(self, SBOL_MODEL, Model,
                                   '0', '*', None)
-        self.sequences = OwnedObject(self, SBOL_SEQUENCE,
+        self.sequences = OwnedObject(self, SBOL_SEQUENCE, Sequence,
                                      '0', '*', None)
-        self.collections = OwnedObject(self, SBOL_COLLECTION,
+        self.collections = OwnedObject(self, SBOL_COLLECTION, Collection,
                                        '0', '*', None)
-        self.activities = OwnedObject(self, PROVO_ACTIVITY,
+        self.activities = OwnedObject(self, PROVO_ACTIVITY, Activity,
                                       '0', '*', None)
-        self.plans = OwnedObject(self, PROVO_PLAN,
+        self.plans = OwnedObject(self, PROVO_PLAN, Plan,
                                  '0', '*', None)
-        self.agents = OwnedObject(self, PROVO_AGENT,
+        self.agents = OwnedObject(self, PROVO_AGENT, Agent,
                                   '0', '*', None)
-        self.attachments = OwnedObject(self, SBOL_ATTACHMENT,
+        self.attachments = OwnedObject(self, SBOL_ATTACHMENT, Attachment,
                                        '0', '*', None)
         self.combinatorialderivations = OwnedObject(self,
                                                     SBOL_COMBINATORIAL_DERIVATION,
+                                                    CombinatorialDerivation,
                                                     '0', '*', None)
         self.implementations = OwnedObject(self, SBOL_IMPLEMENTATION,
+                                           Implementation,
                                            '0', '*', None)
         self.sampleRosters = OwnedObject(self, SYSBIO_SAMPLE_ROSTER,
+                                         SampleRoster,
                                          '0', '*', [validation.libsbol_rule_16])
-        self.experiments = OwnedObject(self, SBOL_EXPERIMENT,
+        self.experiments = OwnedObject(self, SBOL_EXPERIMENT, Experiment,
                                        '0', '*', None)
         self.experimentalData = OwnedObject(self, SBOL_EXPERIMENTAL_DATA,
+                                            ExperimentalData,
                                             '0', '*', None)
         self._citations = URIProperty(self, PURL_URI + "bibliographicCitation",
                                       '0', '*', None)

--- a/sbol/interaction.py
+++ b/sbol/interaction.py
@@ -1,6 +1,9 @@
+from .component import FunctionalComponent
 from .identified import Identified
-from .validation import *
+from .measurement import Measurement
 from .object import *
+from .participation import Participation
+from .validation import *
 
 
 class Interaction(Identified):
@@ -9,12 +12,15 @@ class Interaction(Identified):
         super().__init__(rdf_type, uri)
         self.functionalComponents = OwnedObject(self,
                                                 SBOL_FUNCTIONAL_COMPONENTS,
+                                                FunctionalComponent,
                                                 '0', '*', [libsbol_rule_18])
         self._types = URIProperty(self, SBOL_TYPES,
                                   '1', '*', [], interaction_type)
         self.participations = OwnedObject(self, SBOL_PARTICIPATIONS,
+                                          Participation,
                                           '0', '*', [])
         self.measurements = OwnedObject(self, SBOL_MEASUREMENTS,
+                                        Measurement,
                                         '0', '*', [])
         # TODO hidden properties
 

--- a/sbol/module.py
+++ b/sbol/module.py
@@ -1,5 +1,7 @@
-from .identified import Identified
 from .constants import *
+from .identified import Identified
+from .mapsto import MapsTo
+from .measurement import Measurement
 from .property import OwnedObject, ReferencedObject
 
 
@@ -10,5 +12,7 @@ class Module(Identified):
         self.definition = ReferencedObject(self, SBOL_DEFINITION,
                                            SBOL_MODULE_DEFINITION,
                                            '1', '1', [], definition)
-        self.mapsTos = OwnedObject(self, SBOL_MAPS_TOS, '0', '*', [])
-        self.measurements = OwnedObject(self, SBOL_MEASUREMENTS, '0', '*', [])
+        self.mapsTos = OwnedObject(self, SBOL_MAPS_TOS, MapsTo,
+                                   '0', '*', [])
+        self.measurements = OwnedObject(self, SBOL_MEASUREMENTS,
+                                        Measurement, '0', '*', [])

--- a/sbol/moduledefinition.py
+++ b/sbol/moduledefinition.py
@@ -1,5 +1,8 @@
-from .toplevel import *
+from .component import FunctionalComponent
+from .interaction import Interaction
+from .module import Module
 from .property import *
+from .toplevel import *
 
 
 class ModuleDefinition(TopLevel):
@@ -84,10 +87,14 @@ class ModuleDefinition(TopLevel):
         self._roles = URIProperty(self, SBOL_ROLES, '0', '*', None)
         self.models = ReferencedObject(self, SBOL_MODELS,
                                        SBOL_MODEL, '0', '*', [])
-        self.functionalComponents = OwnedObject(self, SBOL_FUNCTIONAL_COMPONENTS,
+        self.functionalComponents = OwnedObject(self,
+                                                SBOL_FUNCTIONAL_COMPONENTS,
+                                                FunctionalComponent,
                                                 '0', '*', [])
-        self.modules = OwnedObject(self, SBOL_MODULES, '0', '*', [])
+        self.modules = OwnedObject(self, SBOL_MODULES, Module,
+                                   '0', '*', [])
         self.interactions = OwnedObject(self, SBOL_INTERACTIONS,
+                                        Interaction,
                                         '0', '*', [libsbol_rule_17])
 
     @property

--- a/sbol/participation.py
+++ b/sbol/participation.py
@@ -1,6 +1,8 @@
-from .identified import Identified
-from .constants import *
 from rdflib import URIRef
+
+from .constants import *
+from .identified import Identified
+from .measurement import Measurement
 from .property import URIProperty, ReferencedObject, OwnedObject
 
 
@@ -13,7 +15,8 @@ class Participation(Identified):
         self.participant = ReferencedObject(self, SBOL_PARTICIPANT,
                                             SBOL_FUNCTIONAL_COMPONENT,
                                             '1', '1', [], participant)
-        self.measurements = OwnedObject(self, SBOL_MEASUREMENTS, '0', '*', [])
+        self.measurements = OwnedObject(self, SBOL_MEASUREMENTS,
+                                        Measurement, '0', '*', [])
 
     @property
     def roles(self):

--- a/sbol/provo.py
+++ b/sbol/provo.py
@@ -106,7 +106,8 @@ class Agent(TopLevel):
     These agents should be annotated with additional information,
     such as software version needed to be able to run the same software again.
     """
-    def __init__(self, uri=URIRef("example"), version=VERSION_STRING, rdf_type=PROVO_AGENT):
+    def __init__(self, uri=URIRef("example"), version=VERSION_STRING,
+                 rdf_type=PROVO_AGENT):
         """Constructor.
 
         :param uri: A full URI including a scheme, namespace, and identifier.
@@ -187,8 +188,9 @@ class Activity(TopLevel):
         derived from this one.
         """
         super().__init__(rdf_type, uri, version)
-        self.plan = OwnedObject(self, PROVO_PLAN, '0', '1', [libsbol_rule_22])
-        self.agent = OwnedObject(self, PROVO_AGENT,
+        self.plan = OwnedObject(self, PROVO_PLAN, Plan,
+                                '0', '1', [libsbol_rule_22])
+        self.agent = OwnedObject(self, PROVO_AGENT, Agent,
                                  '0', '1', [libsbol_rule_22])
         self._types = URIProperty(self, SBOL_TYPES, '0', '1', [])
         self._startedAtTime = LiteralProperty(self, PROVO_STARTED_AT_TIME,
@@ -197,9 +199,10 @@ class Activity(TopLevel):
                                             '0', '1', [])
         self.wasInformedBy = ReferencedObject(self, PROVO_WAS_INFORMED_BY,
                                               PROVO_ACTIVITY, '0', '*', [])
-        self.usages = OwnedObject(self, PROVO_QUALIFIED_USAGE, '0', '*', [])
+        self.usages = OwnedObject(self, PROVO_QUALIFIED_USAGE, Usage,
+                                  '0', '*', [])
         self.associations = OwnedObject(self, PROVO_QUALIFIED_ASSOCIATION,
-                                        '0', '*', [])
+                                        Association, '0', '*', [])
 
     @property
     def types(self):

--- a/sbol/sequenceannotation.py
+++ b/sbol/sequenceannotation.py
@@ -1,5 +1,6 @@
-from .identified import Identified
 from .constants import *
+from .identified import Identified
+from .location import Location
 from .property import OwnedObject, URIProperty
 
 
@@ -17,7 +18,8 @@ class SequenceAnnotation(Identified):
         """
         super().__init__(SBOL_SEQUENCE_ANNOTATION, uri, version)
         self.component = None  # TODO support ReferencedObject
-        self.locations = OwnedObject(self, SBOL_LOCATIONS, '0', '*', [])
+        self.locations = OwnedObject(self, SBOL_LOCATIONS, Location,
+                                     '0', '*', [])
         self._roles = URIProperty(self, SBOL_ROLES, '0', '*', [])
 
     @property

--- a/sbol/test/__init__.py
+++ b/sbol/test/__init__.py
@@ -1,16 +1,28 @@
 import unittest
 import sys
 from .test_componentdefinition import TestComponentDefinitions
+from .test_design import TestDesign
 from .test_document import TestDocument
 from .test_identified import TestIdentified
 from .test_config import TestConfig
+from .test_ownedobject import TestOwnedObject
 from .test_property import TestProperty
 from .test_roundtrip import TestRoundTripSBOL2, TestRoundTripFailSBOL2
 from .test_tutorial import TestSbolTutorial
 
 
-def runTests(test_list=(TestDocument, TestIdentified, TestConfig, TestProperty,
-                        TestSbolTutorial, TestComponentDefinitions)):
+def runTests(test_list=None):
+    if test_list is None:
+        test_list = [
+            TestComponentDefinitions,
+            TestConfig,
+            TestDesign,
+            TestDocument,
+            TestIdentified,
+            TestOwnedObject,
+            TestProperty,
+            TestSbolTutorial,
+        ]
     suite_list = []
     loader = unittest.TestLoader()
     for test_class in test_list:

--- a/sbol/test/test_design.py
+++ b/sbol/test/test_design.py
@@ -1,0 +1,23 @@
+import unittest
+import sbol
+
+
+class TestDesign(unittest.TestCase):
+
+    # This is expected to fail because `design.structure` and
+    # `design.function` both return a ReferencedObject instance instead
+    # of None. We'll have to deal with that at some point if we want
+    # to maintain backward compatibility.
+    @unittest.expectedFailure
+    def test_constructor_empty(self):
+        # There was a bug where a Design could not be constructed with
+        # no arguments. The original pySBOL allows this. This test
+        # ensures backward compatibility with the empty constructor
+        # call.
+        design = sbol.Design()
+        self.assertIsNone(design.structure)
+        self.assertIsNone(design.function)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sbol/test/test_document.py
+++ b/sbol/test/test_document.py
@@ -138,5 +138,6 @@ class TestDocument(unittest.TestCase):
         self.assertNotEqual(found, -1)
         self.assertIsNotNone(found)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/sbol/test/test_ownedobject.py
+++ b/sbol/test/test_ownedobject.py
@@ -1,0 +1,39 @@
+import unittest
+import sbol
+
+
+class TestOwnedObject(unittest.TestCase):
+
+    # Test all the classes that contain OwnedObjects to be sure they
+    # provide a callable builder argument
+    def test_containers(self):
+        # Note: Alphabetical Order
+        x = sbol.Activity()
+        x = sbol.CombinatorialDerivation()
+        x = sbol.Component()
+        x = sbol.ComponentDefinition()
+        x = sbol.Document()
+        x = sbol.Interaction()
+        x = sbol.Module()
+        x = sbol.ModuleDefinition()
+        x = sbol.Participation()
+        x = sbol.SequenceAnnotation()
+
+    # These are classes that are considered outside the core, and thus
+    # outside the beta. They use OwnedObject, so they will need to be
+    # updated in the future.
+    @unittest.expectedFailure
+    def test_non_beta_classes(self):
+        # These are all in dbtl.py
+        x = sbol.Analysis()
+        x = sbol.Build()
+        x = sbol.Design()
+
+    def test_create(self):
+        doc = sbol.Document()
+        thing = doc.moduleDefinitions.create('thing1')
+        self.assertIs(type(thing), sbol.ModuleDefinition)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The implementation itself is easy. This requires a breaking change to
the OwnedObject API though. Fortunately, OwnedObject is not a public
API.

Added an argument in position three for a builder function that will
accept a single string argument and construct an instanace appropriate
to this OwnedObject container. The builder function is used to
implement the OwnedObject.create() method.