### PR TITLE
Fix OwnedObject.create() and OwnedObject.__getitem__()

### DIFF
--- a/sbol/document.py
+++ b/sbol/document.py
@@ -1,3 +1,4 @@
+import collections.abc
 from .identified import *
 from .config import *
 from .constants import *
@@ -231,7 +232,11 @@ class Document(Identified):
         :param sbol_obj: module definition
         :return: None
         """
-        self.add(sbol_obj)
+        if isinstance(sbol_obj, collections.abc.Iterable):
+            for obj in sbol_obj:
+                self.add(obj)
+        else:
+            self.add(sbol_obj)
 
     def addSequence(self, sbol_obj):
         """

--- a/sbol/identified.py
+++ b/sbol/identified.py
@@ -145,7 +145,7 @@ class Identified(SBOLObject):
         if self.parent is None:
             raise Exception('update_uri: Parent cannot be None')
         parent = self.parent
-        if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS) is True:
+        if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS.value) is True:
             # Form compliant URI for child object
             persistent_id = parent.properties[SBOL_PERSISTENT_IDENTITY][0]
             persistent_id = os.path.join(persistent_id, self.displayId)
@@ -163,7 +163,7 @@ class Identified(SBOLObject):
                 raise SBOLError("Cannot update SBOL-compliant URI. The URI " +
                                 self.identity + " is not unique",
                                 SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
-            for rdf_type, store in self.owned_objects:
+            for rdf_type, store in self.owned_objects.items():
                 if rdf_type not in self._hidden_properties:
                     for nested_obj in store:
                         nested_obj.update_uri()

--- a/sbol/moduledefinition.py
+++ b/sbol/moduledefinition.py
@@ -194,7 +194,18 @@ class ModuleDefinition(TopLevel):
         of the callback as an argument.
         :return: A list of all ModuleDefinitions in the hierarchy.
         """
-        raise NotImplementedError("Not yet implemented")
+        if callback:
+            callback(self, user_data)
+        result = [self]
+        if self.modules:
+            # I have child modules
+            for m in self.modules:
+                self.logger.warning('type(m): %r', type(m))
+                self.logger.warning('m.definition: %r', m.definition.get(0))
+                md = self.doc.find(str(m.definition.get(0)))
+                self.logger.info('Found %r', md)
+                result.extend(md.applyToModuleHierarchy(callback, user_data))
+        return result
 
     def assemble(self, list_of_modules):
         """Assemble a high-level ModuleDefinition from lower-level submodules.

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -183,9 +183,13 @@ class SBOLObject:
                 continue
             for obj in store:
                 matches += obj.find_property_value(uri, value)
-        value_store = self.properties[uri]
-        for val in value_store:
-            matches.append(val)
+        try:
+            value_store = self.properties[uri]
+            for val in value_store:
+                matches.append(val)
+        except KeyError:
+            # It is ok that uri is not in properties
+            pass
         return matches
 
     def find_reference(self, uri):

--- a/sbol/property.py
+++ b/sbol/property.py
@@ -406,31 +406,33 @@ class OwnedObject(URIProperty):
         uri - the name of the object
 
         """
-        return self.builder(uri)
+        obj = self.builder(uri=uri)
+        self.add(obj)
+        return obj
 
     def add(self, sbol_obj):
         if self._sbol_owner is not None:
             if sbol_obj.is_top_level() and self._sbol_owner.doc is not None:
                 self._sbol_owner.doc.add(sbol_obj)
-        else:
-            object_store = self._sbol_owner.owned_objects[self._rdf_type]
-            if sbol_obj in object_store:
-                raise SBOLError("The object " + sbol_obj.identity +
-                                " is already contained by the " +
-                                self._rdf_type + " property",
-                                SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
-            # Add to Document and check for uniqueness of URI
-            if self._sbol_owner.doc is not None:
-                sbol_obj.doc = self._sbol_owner.doc
-            # Add to parent object
-            object_store.append(sbol_obj)
-            sbol_obj.parent = self._sbol_owner
-            # Update URI for the argument object and all its children,
-            # if SBOL-compliance is enabled.
-            sbol_obj.update_uri()
+            else:
+                object_store = self._sbol_owner.owned_objects[self._rdf_type]
+                if sbol_obj in object_store:
+                    raise SBOLError("The object " + sbol_obj.identity +
+                                    " is already contained by the " +
+                                    self._rdf_type + " property",
+                                    SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
+                # Add to Document and check for uniqueness of URI
+                if self._sbol_owner.doc is not None:
+                    sbol_obj.doc = self._sbol_owner.doc
+                # Add to parent object
+                object_store.append(sbol_obj)
+                sbol_obj.parent = self._sbol_owner
+                # Update URI for the argument object and all its children,
+                # if SBOL-compliance is enabled.
+                sbol_obj.update_uri()
 
-            # Run validation rules
-            # TODO
+                # Run validation rules
+                # TODO
 
     def __getitem__(self, id):
         if type(id) is int:

--- a/sbol/property.py
+++ b/sbol/property.py
@@ -516,13 +516,14 @@ class OwnedObject(URIProperty):
                 persistentIdentity = parent_obj.properties[SBOL_PERSISTENT_IDENTITY][0]
             if SBOL_VERSION in parent_obj.properties:
                 version = parent_obj.properties[SBOL_VERSION][0]
-                compliant_uri = URIRef(os.path.join(persistentIdentity, uri, version))
+                compliant_uri = os.path.join(persistentIdentity, uri, version)
             else:
-                compliant_uri = URIRef(os.path.join(persistentIdentity, uri))
+                compliant_uri = os.path.join(persistentIdentity, uri)
             if Config.getOption(ConfigOptions.VERBOSE.value) is True:
                 print('Searching for non-TopLevel: ' + compliant_uri)
             for obj in object_store:
-                if obj.identity == compliant_uri:
+                # identity is a string, so cast the URIRef compliant_uri to a string
+                if obj.identity == str(compliant_uri):
                     return obj
 
     def get(self, uri):

--- a/sbol/test/test_document.py
+++ b/sbol/test/test_document.py
@@ -138,6 +138,13 @@ class TestDocument(unittest.TestCase):
         self.assertNotEqual(found, -1)
         self.assertIsNotNone(found)
 
+    def test_lookup(self):
+        # Test simple key lookup via the __getitem__() method
+        doc = sbol.Document()
+        md = doc.moduleDefinitions.create('foo')
+        md2 = doc.moduleDefinitions[md.displayId]
+        self.assertEqual(md.identity, md2.identity)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sbol/test/test_ownedobject.py
+++ b/sbol/test/test_ownedobject.py
@@ -4,6 +4,13 @@ import sbol
 
 class TestOwnedObject(unittest.TestCase):
 
+    def setUp(self):
+        # All tests in this file use the default homespace
+        sbol.setHomespace('http://examples.org')
+        # All tests in this file use SBOL compliant URIs
+        sbol.Config.setOption(sbol.ConfigOptions.SBOL_COMPLIANT_URIS.value, True)
+        sbol.Config.setOption(sbol.ConfigOptions.SBOL_TYPED_URIS.value, True)
+
     # Test all the classes that contain OwnedObjects to be sure they
     # provide a callable builder argument
     def test_containers(self):
@@ -33,6 +40,44 @@ class TestOwnedObject(unittest.TestCase):
         doc = sbol.Document()
         thing = doc.moduleDefinitions.create('thing1')
         self.assertIs(type(thing), sbol.ModuleDefinition)
+        # md = doc.moduleDefinitions.get(thing.identity)
+        # self.assertEqual(thing.identity, md.identity)
+
+    def test_create2(self):
+        # Test that the create adds the new object to the owned object.
+        #
+        # This seems to be a problem in the implementation of
+        # ModuleDefinition.assemble()
+        doc = sbol.Document()
+        md = doc.moduleDefinitions.create('thing1')
+        self.assertEqual(len(md.modules), 0)
+        module = md.modules.create('thing2')
+        self.assertEqual(len(md.modules), 1)
+
+    def test_uri_generation(self):
+        doc = sbol.Document()
+        md = doc.moduleDefinitions.create('foo')
+        self.assertEqual(md.identity, 'http://examples.org/ModuleDefinition/foo/1')
+        m = md.modules.create('bar')
+        self.assertEqual(m.identity, 'http://examples.org/ModuleDefinition/foo/bar/1')
+
+    # def test_displayId_lookup(self):
+    #     # Test lookup of an object by its display Id via the
+    #     # __getitem__() method.
+    #     doc = sbol.Document()
+    #     md = doc.moduleDefinitions.create('foo')
+    #     m = md.modules.create('bar')
+    #     m2 = md.modules['bar']
+    #     self.assertEqual(m.identity, m2.identity)
+
+    # def test_uri_lookup(self):
+    #     # Test lookup of an object by its URI via the
+    #     # __getitem__() method.
+    #     doc = sbol.Document()
+    #     md = doc.moduleDefinitions.create('foo')
+    #     m = md.modules.create('bar')
+    #     m2 = md.modules[m.identity]
+    #     self.assertEqual(m.identity, m2.identity)
 
 
 if __name__ == '__main__':

--- a/sbol/test/test_ownedobject.py
+++ b/sbol/test/test_ownedobject.py
@@ -61,23 +61,23 @@ class TestOwnedObject(unittest.TestCase):
         m = md.modules.create('bar')
         self.assertEqual(m.identity, 'http://examples.org/ModuleDefinition/foo/bar/1')
 
-    # def test_displayId_lookup(self):
-    #     # Test lookup of an object by its display Id via the
-    #     # __getitem__() method.
-    #     doc = sbol.Document()
-    #     md = doc.moduleDefinitions.create('foo')
-    #     m = md.modules.create('bar')
-    #     m2 = md.modules['bar']
-    #     self.assertEqual(m.identity, m2.identity)
+    def test_displayId_lookup(self):
+        # Test lookup of an object by its display Id via the
+        # __getitem__() method.
+        doc = sbol.Document()
+        md = doc.moduleDefinitions.create('foo')
+        m = md.modules.create('bar')
+        m2 = md.modules['bar']
+        self.assertEqual(m.identity, m2.identity)
 
-    # def test_uri_lookup(self):
-    #     # Test lookup of an object by its URI via the
-    #     # __getitem__() method.
-    #     doc = sbol.Document()
-    #     md = doc.moduleDefinitions.create('foo')
-    #     m = md.modules.create('bar')
-    #     m2 = md.modules[m.identity]
-    #     self.assertEqual(m.identity, m2.identity)
+    def test_uri_lookup(self):
+        # Test lookup of an object by its URI via the
+        # __getitem__() method.
+        doc = sbol.Document()
+        md = doc.moduleDefinitions.create('foo')
+        m = md.modules.create('bar')
+        m2 = md.modules[m.identity]
+        self.assertEqual(m.identity, m2.identity)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On the way to [implementing applyToModuleHierarchy](#6), it turned out that `OwnedObject.create()` and `OwnedObject.__getitem__()` were both broken. `OwnedObject.create()` returned a new object but didn't hold on to it like pySBOL does. And once it held onto the object it couldn't find it again via the displayId. All of this is now fixed.

This pull request also includes some initial work towards applyToModuleHierarchy.

Fixes #35 
