### PR TITLE
Fix SBOLObject.find_property_value

### DIFF
--- a/sbol/object.py
+++ b/sbol/object.py
@@ -186,7 +186,8 @@ class SBOLObject:
         try:
             value_store = self.properties[uri]
             for val in value_store:
-                matches.append(val)
+                if val == value:
+                    matches.append(val)
         except KeyError:
             # It is ok that uri is not in properties
             pass

--- a/sbol/test/test_document.py
+++ b/sbol/test/test_document.py
@@ -1,4 +1,5 @@
 import locale
+import logging
 import os
 import unittest
 import sbol
@@ -145,6 +146,18 @@ class TestDocument(unittest.TestCase):
         md2 = doc.moduleDefinitions[md.displayId]
         self.assertEqual(md.identity, md2.identity)
 
+    def test_find_property_value(self):
+        # find_property_value wasn't comparing against the passed
+        # `value` parameter, so it was returning all identities in the
+        # document.
+        sbol.setHomespace('http://examples.org')
+        sbol.Config.setOption('sbol_compliant_uris', True)
+        sbol.Config.setOption('sbol_typed_uris', True)
+        doc = sbol.Document()
+        md = doc.moduleDefinitions.create('foo')
+        test_uri = 'http://examples.org/does/not/exist/1'
+        matches = doc.find_property_value(sbol.SBOL_IDENTITY, test_uri)
+        self.assertEqual(len(matches), 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Use the value parameter to filter the returned values as done in
pySBOL.

Fixes #39 