### PR TITLE
Implement ModuleDefinition.applyToModuleHierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv/**
 .idea/
 .pytest_cache/
 style.txt
+*~

--- a/sbol/moduledefinition.py
+++ b/sbol/moduledefinition.py
@@ -207,10 +207,7 @@ class ModuleDefinition(TopLevel):
         if self.modules:
             # I have child modules
             for m in self.modules:
-                self.logger.warning('type(m): %r', type(m))
-                self.logger.warning('m.definition: %r', m.definition.get(0))
                 md = self.doc.find(str(m.definition.get(0)))
-                self.logger.info('Found %r', md)
                 result.extend(md.applyToModuleHierarchy(callback, user_data))
         return result
 
@@ -222,7 +219,12 @@ class ModuleDefinition(TopLevel):
         :param list_of_modules: A list of submodule ModuleDefinitions.
         :return: None
         """
-        raise NotImplementedError("Not yet implemented")
+        if not Config.getOption('sbol_compliant_uris'):
+            msg = 'This method only works when SBOL-compliance is enabled'
+            raise SBOLError(msg, SBOLError.SBOL_ERROR_COMPLIANCE)
+        for mdef in list_of_modules:
+            m = self.modules.create(mdef.displayId)
+            m.definition.set(mdef.identity)
 
     def getTypeURI(self):
         return SBOL_MODULE_DEFINITION

--- a/sbol/property.py
+++ b/sbol/property.py
@@ -687,9 +687,7 @@ class ReferencedObject(Property):
         if self._sbol_owner is not None:
             if self._rdf_type not in self._sbol_owner.properties:
                 self._sbol_owner.properties[self._rdf_type] = []
-                self._sbol_owner.properties[self._rdf_type].append(uri)
-            else:
-                self._sbol_owner.properties[self._rdf_type][0] = uri
+            self._sbol_owner.properties[self._rdf_type].append(uri)
         else:
             # NOTE: we could raise an exception here, but the
             # original code is not doing anything in this case.

--- a/sbol/test/__init__.py
+++ b/sbol/test/__init__.py
@@ -5,6 +5,7 @@ from .test_design import TestDesign
 from .test_document import TestDocument
 from .test_identified import TestIdentified
 from .test_config import TestConfig
+from .test_moduledefinition import TestModuleDefinition
 from .test_ownedobject import TestOwnedObject
 from .test_property import TestProperty
 from .test_roundtrip import TestRoundTripSBOL2, TestRoundTripFailSBOL2
@@ -19,6 +20,7 @@ def runTests(test_list=None):
             TestDesign,
             TestDocument,
             TestIdentified,
+            TestModuleDefinition,
             TestOwnedObject,
             TestProperty,
             TestSbolTutorial,

--- a/sbol/test/test_moduledefinition.py
+++ b/sbol/test/test_moduledefinition.py
@@ -1,0 +1,52 @@
+import logging
+import unittest
+import sbol
+
+
+class TestModuleDefinition(unittest.TestCase):
+
+    def setUp(self):
+        # All tests in this file use the default homespace
+        sbol.setHomespace('http://examples.org')
+        # All tests in this file use SBOL compliant URIs
+        sbol.Config.setOption(sbol.ConfigOptions.SBOL_COMPLIANT_URIS.value, True)
+        sbol.Config.setOption(sbol.ConfigOptions.SBOL_TYPED_URIS.value, True)
+
+    # Borrowed from libSBOL/wrapper/unit_tests.py
+    def testApplyCallbackRecursively(self):
+        # Assemble module hierarchy
+        doc = sbol.Document()
+        root = sbol.ModuleDefinition('root')
+        sub = sbol.ModuleDefinition('sub')
+        leaf = sbol.ModuleDefinition('leaf')
+        doc.addModuleDefinition([root, sub, leaf])
+        root.assemble([sub])
+        sub.assemble([leaf])
+
+        # Define callback which performs an operation on the given ModuleDefinition
+        def callback(md, params):
+            level = params[0]
+            level += 1
+            params[0] = level
+
+        # Apply callback
+        level = 0
+        params = [level]
+        flattened_module_tree = root.applyToModuleHierarchy(callback, params)
+        level = params[0]
+        flattened_module_tree = [md.identity for md in flattened_module_tree]
+        expected_module_tree = [md.identity for md in [root, sub, leaf]]
+        self.assertSequenceEqual(flattened_module_tree, expected_module_tree)
+        self.assertEqual(level, 3)
+
+    def testAssemble(self):
+        # Assemble module hierarchy
+        doc = sbol.Document()
+        root = sbol.ModuleDefinition('root')
+        sub = sbol.ModuleDefinition('sub')
+        doc.addModuleDefinition([root, sub])
+        root.assemble([sub])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
All the supporting code is implemented and/or fixed, so at long last,
here is MD.applyToModuleHierarchy.

Fixes #6 
