### PR TITLE
Use platform independent URI path joining.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,27 @@
-language: python
-# in parallel, run tests in these environments
-python:
-    - "3.6"
-    - "3.7"
-os:
-  - linux
-  - windows
-# command to install dependencies
-install:
-    - pip install .
-# tests to run
-script:
-    - python3 -c "import sbol; sbol.testSBOL()"
-    - travis_wait python3 -c "import sbol; sbol.testRoundTrip()"
+language: generic
 
-notifications:
-    email:
-        - tollben@umich.edu
+matrix:
+  include:
+    - os: linux
+      language: python
+      python: 3.6
+
+    - os: linux
+      language: python
+      python: 3.7
+
+    - os: windows
+      language: shell
+      before_install:
+       - choco install python3 --version 3.7.6 --no-progress -y
+      install:
+       - C:\\Python37\\python -m pip install .
+      script:
+       - C:\\Python37\\python -c "import sbol; sbol.testSBOL()"
+
+install:
+  - python3 -m pip install .
+
+script:
+  - python3 -c "import sbol; sbol.testSBOL()"
+  - travis_wait python3 -c "import sbol; sbol.testRoundTrip()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Thanks to https://github.com/joerick/cibuildwheel for windows build
+# commands
+
 language: generic
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - os: windows
       language: shell
       before_install:
-       - choco install python3 --version 3.7.6 --no-progress -y
+       - choco install python3 --version=3.7.6 --no-progress -y
       install:
        - C:\\Python37\\python -m pip install .
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python:
     - "3.6"
     - "3.7"
+os:
+  - linux
+  - windows
 # command to install dependencies
 install:
     - pip install .

--- a/sbol/componentdefinition.py
+++ b/sbol/componentdefinition.py
@@ -1,7 +1,10 @@
+from rdflib import URIRef
+
 from .component import Component
-from .toplevel import *
+from .constants import *
+from .toplevel import TopLevel
 from . import validation
-from .property import URIProperty
+from .property import OwnedObject, ReferencedObject, URIProperty
 from .sequence import Sequence
 from .sequenceannotation import SequenceAnnotation
 from .sequenceconstraint import SequenceConstraint

--- a/sbol/document.py
+++ b/sbol/document.py
@@ -98,13 +98,13 @@ class Document(Identified):
         self._namespaces = {}
         self.resource_namespaces = set()
         self.designs = OwnedObject(self, SYSBIO_DESIGN, Design,
-                                   '0', '*', [libsbol_rule_11])
+                                   '0', '*', [validation.libsbol_rule_11])
         self.builds = OwnedObject(self, SYSBIO_BUILD, Build,
-                                  '0', '*', [libsbol_rule_12])
+                                  '0', '*', [validation.libsbol_rule_12])
         self.tests = OwnedObject(self, SYSBIO_TEST, Test,
-                                 '0', '*', [libsbol_rule_13])
+                                 '0', '*', [validation.libsbol_rule_13])
         self.analyses = OwnedObject(self, SYSBIO_ANALYSIS, Analysis,
-                                    '0', '*', [libsbol_rule_14])
+                                    '0', '*', [validation.libsbol_rule_14])
         self.componentDefinitions = OwnedObject(self,
                                                 SBOL_COMPONENT_DEFINITION,
                                                 ComponentDefinition,

--- a/sbol/identified.py
+++ b/sbol/identified.py
@@ -92,14 +92,14 @@ class Identified(SBOLObject):
                 if version != '':
                     self._identity.set(
                         URIRef(posixpath.join(getHomespace(),
-                                            self.getClassName(type_uri),
-                                            uri, version))
+                                              self.getClassName(type_uri),
+                                              uri, version))
                     )
                 else:
                     self._identity.set(
                         URIRef(posixpath.join(getHomespace(),
-                                            self.getClassName(type_uri),
-                                            uri))
+                                              self.getClassName(type_uri),
+                                              uri))
                     )
             else:
                 if version != '':

--- a/sbol/identified.py
+++ b/sbol/identified.py
@@ -1,4 +1,4 @@
-import os
+import posixpath
 
 from .object import SBOLObject
 from .config import Config
@@ -87,31 +87,31 @@ class Identified(SBOLObject):
         self._description = LiteralProperty(self, SBOL_DESCRIPTION, '0', '1', None)
         if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS.value) is True:
             self._displayId.set(uri)
-            self._persistentIdentity.set(URIRef(os.path.join(getHomespace(), uri)))
+            self._persistentIdentity.set(URIRef(posixpath.join(getHomespace(), uri)))
             if Config.getOption(ConfigOptions.SBOL_TYPED_URIS.value) is True:
                 if version != '':
                     self._identity.set(
-                        URIRef(os.path.join(getHomespace(),
+                        URIRef(posixpath.join(getHomespace(),
                                             self.getClassName(type_uri),
                                             uri, version))
                     )
                 else:
                     self._identity.set(
-                        URIRef(os.path.join(getHomespace(),
+                        URIRef(posixpath.join(getHomespace(),
                                             self.getClassName(type_uri),
                                             uri))
                     )
             else:
                 if version != '':
                     self._identity.set(
-                        URIRef(os.path.join(getHomespace(), uri, version)))
+                        URIRef(posixpath.join(getHomespace(), uri, version)))
                 else:
                     self._identity.set(
-                        URIRef(os.path.join(getHomespace(), uri)))
+                        URIRef(posixpath.join(getHomespace(), uri)))
         elif hasHomespace():
-            self._identity.set(URIRef(os.path.join(getHomespace(), uri)))
+            self._identity.set(URIRef(posixpath.join(getHomespace(), uri)))
             self._persistentIdentity.set(
-                URIRef(os.path.join(getHomespace(), uri)))
+                URIRef(posixpath.join(getHomespace(), uri)))
         # self._identity.validate() # TODO
 
     @property
@@ -169,12 +169,12 @@ class Identified(SBOLObject):
         if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS.value) is True:
             # Form compliant URI for child object
             persistent_id = parent.properties[SBOL_PERSISTENT_IDENTITY][0]
-            persistent_id = os.path.join(persistent_id, self.displayId)
+            persistent_id = posixpath.join(persistent_id, self.displayId)
             if len(parent.properties[SBOL_VERSION]) > 0:
                 version = parent.properties[SBOL_VERSION][0]
             else:
                 version = VERSION_STRING
-            obj_id = os.path.join(persistent_id, version)
+            obj_id = posixpath.join(persistent_id, version)
             # Reset SBOLCompliant properties
             self._identity.set(obj_id)
             self._persistentIdentity.set(persistent_id)

--- a/sbol/identified.py
+++ b/sbol/identified.py
@@ -1,5 +1,12 @@
-from .object import *
+import os
+
+from .object import SBOLObject
+from .config import Config
+from .config import ConfigOptions
+from .config import getHomespace
+from .config import hasHomespace
 from .constants import *
+from .property import LiteralProperty, URIProperty
 from . import validation
 
 

--- a/sbol/moduledefinition.py
+++ b/sbol/moduledefinition.py
@@ -95,7 +95,7 @@ class ModuleDefinition(TopLevel):
                                    '0', '*', [])
         self.interactions = OwnedObject(self, SBOL_INTERACTIONS,
                                         Interaction,
-                                        '0', '*', [libsbol_rule_17])
+                                        '0', '*', [validation.libsbol_rule_17])
 
     @property
     def roles(self):

--- a/sbol/moduledefinition.py
+++ b/sbol/moduledefinition.py
@@ -1,3 +1,4 @@
+from . import validation
 from .component import FunctionalComponent
 from .interaction import Interaction
 from .module import Module

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -1,11 +1,12 @@
+import logging
+import posixpath
+
+from rdflib import RDF
+import rdflib
+
 from .property import *
 from .validation import *
 from .config import *
-from rdflib import RDF
-import logging
-from logging.config import fileConfig
-
-import rdflib
 
 
 class SBOLObject:
@@ -84,7 +85,7 @@ class SBOLObject:
             self._identity = URIProperty(self, SBOL_IDENTITY,
                                          '0', '1', [sbol_rule_10202], uri)
         if hasHomespace():
-            uri = os.path.join(getHomespace(), uri)
+            uri = posixpath.join(getHomespace(), uri)
             self._identity = URIProperty(self, SBOL_IDENTITY,
                                          '0', '1', [sbol_rule_10202], uri)
 

--- a/sbol/property.py
+++ b/sbol/property.py
@@ -1,13 +1,19 @@
-from rdflib import Literal
-from .sbolerror import *
-from .config import Config, ConfigOptions, getHomespace, parseClassName, parsePropertyName
-from .constants import *
-import os
-import logging
-from logging.config import fileConfig
 from abc import ABC, abstractmethod
+import logging
+import os
+import posixpath
 
 import rdflib
+from rdflib import Literal
+
+from .config import Config
+from .config import ConfigOptions
+from .config import getHomespace
+from .config import parseClassName
+from .config import parsePropertyName
+from .constants import *
+from .sbolerror import SBOLError
+from .sbolerror import SBOLErrorCode
 
 
 def sort_version(obj):
@@ -506,9 +512,9 @@ class OwnedObject(URIProperty):
         for ns in resource_namespaces:
             # Assume the parent object is TopLevel and form the compliant URI
             if typedURI is True:
-                compliant_uri = os.path.join(ns, parseClassName(self._rdf_type), uri)
+                compliant_uri = posixpath.join(ns, parseClassName(self._rdf_type), uri)
             else:
-                compliant_uri = os.path.join(ns, uri)
+                compliant_uri = posixpath.join(ns, uri)
             compliant_uri += os.sep
             compliant_uri = URIRef(compliant_uri)
             persistent_id_matches = []
@@ -529,9 +535,9 @@ class OwnedObject(URIProperty):
                 persistentIdentity = parent_obj.properties[SBOL_PERSISTENT_IDENTITY][0]
             if SBOL_VERSION in parent_obj.properties:
                 version = parent_obj.properties[SBOL_VERSION][0]
-                compliant_uri = os.path.join(persistentIdentity, uri, version)
+                compliant_uri = posixpath.join(persistentIdentity, uri, version)
             else:
-                compliant_uri = os.path.join(persistentIdentity, uri)
+                compliant_uri = posixpath.join(persistentIdentity, uri)
             if Config.getOption(ConfigOptions.VERBOSE.value) is True:
                 print('Searching for non-TopLevel: ' + compliant_uri)
             for obj in object_store:

--- a/sbol/provo.py
+++ b/sbol/provo.py
@@ -1,6 +1,13 @@
+from rdflib import URIRef
+
+from . import validation
+from .constants import *
+from .identified import Identified
+from .property import LiteralProperty
 from .property import OwnedObject
 from .property import ReferencedObject
-from .toplevel import *
+from .property import URIProperty
+from .toplevel import TopLevel
 
 
 class Association(Identified):

--- a/sbol/provo.py
+++ b/sbol/provo.py
@@ -1,3 +1,5 @@
+from .property import OwnedObject
+from .property import ReferencedObject
 from .toplevel import *
 
 
@@ -189,9 +191,9 @@ class Activity(TopLevel):
         """
         super().__init__(rdf_type, uri, version)
         self.plan = OwnedObject(self, PROVO_PLAN, Plan,
-                                '0', '1', [libsbol_rule_22])
+                                '0', '1', [validation.libsbol_rule_22])
         self.agent = OwnedObject(self, PROVO_AGENT, Agent,
-                                 '0', '1', [libsbol_rule_22])
+                                 '0', '1', [validation.libsbol_rule_22])
         self._types = URIProperty(self, SBOL_TYPES, '0', '1', [])
         self._startedAtTime = LiteralProperty(self, PROVO_STARTED_AT_TIME,
                                               '0', '1', [])

--- a/sbol/sequence.py
+++ b/sbol/sequence.py
@@ -1,5 +1,10 @@
-from .toplevel import *
 from deprecated import deprecated
+
+from rdflib import URIRef
+
+from .constants import *
+from .property import LiteralProperty
+from .toplevel import TopLevel
 
 
 class Sequence(TopLevel):

--- a/sbol/toplevel.py
+++ b/sbol/toplevel.py
@@ -1,12 +1,15 @@
-from .identified import *
-from .config import *
+import posixpath
+
+from .config import Config
+from .config import ConfigOptions
+from .config import getHomespace
+from .constants import *
+from .identified import Identified
 
 
 class TopLevel(Identified):
     """All SBOL classes derived from TopLevel appear as top level nodes
     in the RDF/XML document tree and SBOL files."""
-
-    attachments = None
 
     def __init__(self, type_uri=SBOL_TOP_LEVEL,
                  uri=URIRef("example"), version=VERSION_STRING):
@@ -15,9 +18,9 @@ class TopLevel(Identified):
         if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS.value) is True:
             if Config.getOption(ConfigOptions.SBOL_TYPED_URIS.value) is True:
                 self._persistentIdentity.set(
-                    os.path.join(getHomespace(),
-                                 self.getClassName(type_uri),
-                                 self.displayId))
+                    posixpath.join(getHomespace(),
+                                   self.getClassName(type_uri),
+                                   self.displayId))
 
     def addToDocument(self, document):
         raise NotImplementedError("Not yet implemented")


### PR DESCRIPTION
When URIs are constructed they must have forward slashes. This requires a path joining utility that always uses forward slashes. `os.path.join` is platform dependent and uses backslashes on Windows. Replace `os.path.join` with `posixpath.join` to get the proper forward slash separators on all platforms.

All of the `WARNING:rdflib.term:http://my_namespace.org\example does not look like a valid URI, trying to serialize this will break.` messages should now be eradicated. 

Fixes #60 