### PR TITLE
Overhaul SBOLObject.__eq__

### DIFF
--- a/sbol/document.py
+++ b/sbol/document.py
@@ -149,6 +149,15 @@ class Document(Identified):
         if filename is not None:
             self.read(filename)
 
+    def __eq__(self, other):
+        if not super().__eq__(other):
+            return False
+        # super().__eq__ will have checked the types so we know other
+        # is a Document at this point.
+        if self._namespaces != other._namespaces:
+            return False
+        return True
+
     @property
     def citations(self):
         return self._citations.value

--- a/sbol/interaction.py
+++ b/sbol/interaction.py
@@ -1,9 +1,11 @@
+from .constants import *
 from .component import FunctionalComponent
 from .identified import Identified
 from .measurement import Measurement
-from .object import *
 from .participation import Participation
-from .validation import *
+from .property import OwnedObject
+from .property import URIProperty
+from . import validation
 
 
 class Interaction(Identified):
@@ -13,7 +15,7 @@ class Interaction(Identified):
         self.functionalComponents = OwnedObject(self,
                                                 SBOL_FUNCTIONAL_COMPONENTS,
                                                 FunctionalComponent,
-                                                '0', '*', [libsbol_rule_18])
+                                                '0', '*', [validation.libsbol_rule_18])
         self._types = URIProperty(self, SBOL_TYPES,
                                   '1', '*', [], interaction_type)
         self.participations = OwnedObject(self, SBOL_PARTICIPATIONS,

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -211,6 +211,7 @@ class SBOLObject:
         """
         raise NotImplementedError("Not yet implemented")
 
+    # TODO: Can we deprecate this method?
     def compare(self, comparand):
         """Compare two SBOL objects or Documents. The behavior
         is currently undefined for objects with custom annotations
@@ -221,66 +222,25 @@ class SBOLObject:
         False if they are different.
         """
         # TODO This may work differently than the original method...
-        if type(comparand) != type(self):
-            return False
-        is_equal = True
-        if self.rdf_type != comparand.rdf_type:
-            self.logger.warning(self.identity + ' does not match type of ' + comparand.rdf_type)
-            return False
-        if self.rdf_type == SBOL_DOCUMENT:
-            ns_set = set(())
-            comparand_ns_set = set(())
-            for val in self._namespaces.values():
-                ns_set.add(val)
-            for val in comparand._namespaces.values():
-                comparand_ns_set.add(val)
-            if ns_set != comparand_ns_set:
-                self.logger.warning("NAMESPACES ARE NOT EQUAL!!!")
-                is_equal = False
-        self.logger.debug("Here are my properties: "
-                          + str(self.properties))
-        self.logger.debug("Here are their properties: "
-                          + str(comparand.properties))
-        if self.compare_unordered_lists(self.properties, comparand.properties) is False:
-            self.logger.warning("PROPERTIES ARE NOT EQUAL!!!")
-            is_equal = False
-        self.logger.debug("Here are my owned objects: "
-                          + str(self.owned_objects))
-        self.logger.debug("Here are their owned objects: "
-                          + str(comparand.owned_objects))
-        if self.compare_unordered_lists(self.owned_objects, comparand.owned_objects) is False:
-            self.logger.warning("OWNED OBJECTS ARE NOT EQUAL!!!")
-            is_equal = False
-        return is_equal
-
-    def compare_unordered_lists(self, mine, theirs):
-        """This is a very inefficient hack for comparing two unordered mutable lists.
-
-        We could make some small improvements to this approach,
-        or consider alternatives."""
-        for my_obj in mine:
-            found = False
-            for their_obj in theirs:
-                if my_obj == their_obj:
-                    found = True
-                    break
-            if found is False:
-                return False
-        return True
+        return self == comparand
 
     def __eq__(self, other):
-        """Compare two SBOL objects or Documents. The behavior
-        is currently undefined for objects
-        with custom annotations or extension classes.
+        """Compare two SBOLObjects. The behavior is currently undefined for
+        objects with custom annotations or extension classes.
 
         :param other: The object being compared to this one.
         :return: True if the objects are identical, False if they are different.
+
         """
-        # if other is None or not isinstance(other, SBOLObject):
-        #     return False
-        # if self.rdf_type != other.rdf_type:
-        #     print(self.identity.get() + ' does not match type of ' + other.type())
-        return self.compare(other)
+        if type(other) != type(self):
+            return False
+        if self.rdf_type != other.rdf_type:
+            return False
+        if self.properties != other.properties:
+            return False
+        if self.owned_objects != other.owned_objects:
+            return False
+        return True
 
     def getPropertyValue(self, property_uri):
         """Get the value of a custom annotation property by its URI.

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -1,12 +1,14 @@
 import logging
 import posixpath
 
-from rdflib import RDF
 import rdflib
 
-from .property import *
-from .validation import *
-from .config import *
+from .config import getHomespace
+from .config import hasHomespace
+from .constants import *
+from .property import ReferencedObject
+from .property import URIProperty
+from . import validation
 
 
 class SBOLObject:
@@ -67,7 +69,8 @@ class SBOLObject:
     # [SBOL specification document](http://sbolstandard.org/wp-content/uploads/2015/08/SBOLv2.0.1.pdf).
     _identity = None
 
-    def __init__(self, _rdf_type=URIRef(UNDEFINED), uri=URIRef("example")):
+    def __init__(self, _rdf_type=rdflib.URIRef(UNDEFINED),
+                 uri=rdflib.URIRef("example")):
         """Open-world constructor."""
         self.owned_objects = {}  # map<rdf_type, vector<SBOLObject>>
         self.properties = {}  # map<rdf_type, vector<SBOLObject>>
@@ -80,14 +83,14 @@ class SBOLObject:
             self.logger.debug("Property was not a URIRef: '" +
                               str(uri) + "', " + str(type(uri)))
             self._identity = URIProperty(self, SBOL_IDENTITY,
-                                         '0', '1', [sbol_rule_10202], URIRef(uri))
+                                         '0', '1', [validation.sbol_rule_10202], URIRef(uri))
         else:
             self._identity = URIProperty(self, SBOL_IDENTITY,
-                                         '0', '1', [sbol_rule_10202], uri)
+                                         '0', '1', [validation.sbol_rule_10202], uri)
         if hasHomespace():
             uri = posixpath.join(getHomespace(), uri)
             self._identity = URIProperty(self, SBOL_IDENTITY,
-                                         '0', '1', [sbol_rule_10202], uri)
+                                         '0', '1', [validation.sbol_rule_10202], uri)
 
     @property
     def logger(self):
@@ -371,7 +374,8 @@ class SBOLObject:
         raise NotImplementedError("Implemented by child classes")
 
     def build_graph(self, graph):
-        graph.add((self._identity.getRawValue(), RDF.type, self.rdf_type))
+        graph.add((self._identity.getRawValue(), rdflib.RDF.type,
+                   self.rdf_type))
         for typeURI, proplist in self.properties.items():
             for prop in proplist:
                 graph.add((self._identity.getRawValue(),

--- a/sbol/test/test_document.py
+++ b/sbol/test/test_document.py
@@ -182,6 +182,12 @@ class TestDocument(unittest.TestCase):
         with self.assertRaises(ValueError):
             doc.addNamespace('http://examples.org', 'foo')
 
+    def test_eq(self):
+        doc = sbol.Document()
+        doc2 = sbol.Document()
+        self.assertEqual(doc, doc2)
+        doc.addNamespace('http://example.org#', 'bar')
+        self.assertNotEqual(doc, doc2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/sbol/test/test_object.py
+++ b/sbol/test/test_object.py
@@ -25,6 +25,24 @@ class TestObject(unittest.TestCase):
         name = cd.getPropertyValue(sbol.SBOL_NAME)
         self.assertEqual(name, expected)
 
+    def test_compare(self):
+        # This didn't work because the SBOLObject.__eq__ method was
+        # broken.  See issue https://github.com/llotneb/SBOL/issues/62
+        sbol.setHomespace('http://example.org/Unit_Test')
+        doc = sbol.Document()
+        md1 = doc.moduleDefinitions.create('Foo1')
+        self.assertEqual(len(doc.moduleDefinitions), 1)
+        md2 = doc.moduleDefinitions.create('Foo2')
+        self.assertEqual(len(doc.moduleDefinitions), 2)
+
+    def test_eq(self):
+        sbol.setHomespace('http://example.org/Unit_Test')
+        doc = sbol.Document()
+        md1 = doc.moduleDefinitions.create('Foo1')
+        self.assertEqual(len(doc.moduleDefinitions), 1)
+        md2 = sbol.ModuleDefinition(uri='Foo2')
+        self.assertNotEqual(md1, md2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
SBOLObject.__eq__ was improperly comparing the properties and
owned_object dicts as lists. SBOLObject.__eq__ also did Document
comparison that it had no business doing. Put the Document comparison
in the Document.__eq__ method. Use standard Python equality operations
to compare dictionaries. Make SBOLObject.__eq__ be the primary method
and have SBOLObject.compare call that method instead of the other way
around.

Fixes #62 