### PR TITLE
Add missing partshop methods

### DIFF
--- a/sbol/partshop.py
+++ b/sbol/partshop.py
@@ -225,6 +225,14 @@ class PartShop:
     def getURL(self):
         return self.resource
 
+    # For backward compatibility with pySBOL
+    def getUser(self):
+        return self.user
+
+    # For backward compatibility with pySBOL
+    def getSpoofedURL(self):
+        return self.spoofed_resource
+
     # def addSynBioHubAnnotations(self, doc):
     #     doc.addNamespace("http://wiki.synbiohub.org/wiki/Terms/synbiohub#", "sbh")
     #     for id, toplevel_obj in doc.SBOLObjects:

--- a/sbol/test/test_partshop.py
+++ b/sbol/test/test_partshop.py
@@ -4,9 +4,6 @@ import unittest
 import requests
 
 import sbol
-from sbol.partshop import PartShop
-from sbol.document import Document
-from sbol.sbolerror import SBOLError
 
 
 if 'username' in os.environ:
@@ -22,8 +19,8 @@ else:
 class TestPartShop(unittest.TestCase):
     def test_pull_00(self):
         # Based on tutorial: https://pysbol2.readthedocs.io/en/latest/repositories.html
-        doc = Document()
-        igem = PartShop('https://synbiohub.org')
+        doc = sbol.Document()
+        igem = sbol.PartShop('https://synbiohub.org')
         igem.pull('https://synbiohub.org/public/igem/BBa_R0010/1', doc)
         # print(doc)
         # for obj in doc:
@@ -32,8 +29,8 @@ class TestPartShop(unittest.TestCase):
 
     def test_pull_01(self):
         # Based on tutorial: https://pysbol2.readthedocs.io/en/latest/repositories.html
-        doc = Document()
-        igem = PartShop('https://synbiohub.org/public/igem')
+        doc = sbol.Document()
+        igem = sbol.PartShop('https://synbiohub.org/public/igem')
         igem.pull('BBa_B0032', doc)
         igem.pull('BBa_E0040', doc)
         igem.pull('BBa_B0012', doc)
@@ -43,8 +40,8 @@ class TestPartShop(unittest.TestCase):
         self.assertEqual(7, len(doc))
 
     def test_pull_02(self):
-        doc = Document()
-        ps = PartShop('https://synbiohub.utah.edu/public/RepressionModel')
+        doc = sbol.Document()
+        ps = sbol.PartShop('https://synbiohub.utah.edu/public/RepressionModel')
         ps.pull('CRPb_characterization_Circuit', doc)
         # print(doc)
         # for obj in doc:
@@ -54,29 +51,29 @@ class TestPartShop(unittest.TestCase):
     def test_login(self):
         # NOTE: Add /login because login pages may be different
         # depending on what site you're accessing
-        igem = PartShop('https://synbiohub.org')
+        igem = sbol.PartShop('https://synbiohub.org')
         response = igem.login('johndoe@example.org', 'test')
         self.assertEqual(response.status_code, 200)
 
     def test_login_bad(self):
-        with self.assertRaises(SBOLError):
-            igem = PartShop('https://synbiohub.org')
+        with self.assertRaises(sbol.SBOLError):
+            igem = sbol.PartShop('https://synbiohub.org')
             igem.login('johndoe@example.org', 'test1')
 
     @unittest.skipIf(password is None, "No password supplied")
     def test_submit_00(self):
-        doc = Document()
+        doc = sbol.Document()
         doc.displayId = 'test_collection'
         doc.name = 'test collection'
         doc.description = 'a test collection automatically generated ' \
                           'by the SBOL client library'
-        ps = PartShop('https://hub-staging.sd2e.org')
+        ps = sbol.PartShop('https://hub-staging.sd2e.org')
         ps.login(username, password)
         response = ps.submit(doc, overwrite=1)
         self.assertEqual(response.status_code, 200)
 
     def test_sparqlQuery_00(self):
-        ps = PartShop('https://synbiohub.org')
+        ps = sbol.PartShop('https://synbiohub.org')
         response = ps.login('johndoe', 'test')
         self.assertEqual(response.status_code, 200)
         query = '''
@@ -100,7 +97,7 @@ WHERE {
 
     def test_getURL(self):
         expected_url = 'https://example.org'
-        partShop = PartShop(expected_url)
+        partShop = sbol.PartShop(expected_url)
         self.assertEqual(partShop.getURL(), expected_url)
 
     def test_getUser(self):

--- a/sbol/test/test_partshop.py
+++ b/sbol/test/test_partshop.py
@@ -1,6 +1,9 @@
 import os
 import unittest
 
+import requests
+
+import sbol
 from sbol.partshop import PartShop
 from sbol.document import Document
 from sbol.sbolerror import SBOLError
@@ -99,3 +102,21 @@ WHERE {
         expected_url = 'https://example.org'
         partShop = PartShop(expected_url)
         self.assertEqual(partShop.getURL(), expected_url)
+
+    def test_getUser(self):
+        url = 'https://example.org'
+        partShop = sbol.PartShop(url)
+        self.assertTrue(hasattr(partShop, 'getUser'))
+        self.assertEqual(partShop.getUser(), '')
+        user = 'scott'
+        password = 'tiger'
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            partShop.login(user, password)
+        self.assertEqual(partShop.getUser(), user)
+
+    def test_getSpoofedURL(self):
+        url = 'https://example.org'
+        spoofed_url = 'https://synbiohub.org'
+        partShop = sbol.PartShop(url, spoofed_url=spoofed_url)
+        self.assertTrue(hasattr(partShop, 'getSpoofedURL'))
+        self.assertEqual(partShop.getSpoofedURL(), spoofed_url)


### PR DESCRIPTION
Add PartShop.getUser and PartShop.getSpoofedURL for backward compatibility with pySBOL.

Fixes #75 
