### PR TITLE
Add warning and tests for SBOLError

### DIFF
--- a/sbol/__init__.py
+++ b/sbol/__init__.py
@@ -23,7 +23,7 @@ from .moduledefinition import ModuleDefinition
 from .participation import Participation
 from .partshop import PartShop
 from .provo import Activity
-from .sbolerror import SBOLError
+from .sbolerror import SBOLError, SBOLErrorCode
 from .sequence import Sequence
 from .sequenceannotation import SequenceAnnotation
 

--- a/sbol/sbolerror.py
+++ b/sbol/sbolerror.py
@@ -1,4 +1,5 @@
 from enum import Enum
+import warnings
 
 
 class SBOLErrorCode(Enum):
@@ -23,15 +24,16 @@ class SBOLErrorCode(Enum):
 
 
 class SBOLError(Exception):
-    __message = ''
-    __err = None
 
     def __init__(self, message, err):
-        self.__message = message
-        self.__err = err
+        if isinstance(message, SBOLErrorCode):
+            warnings.warn("SBOLError arguments out of order",
+                          RuntimeWarning)
+        self._message = message
+        self._err = err
 
     def what(self):
-        return self.__message
+        return self._message
 
     def error_code(self):
-        return self.__err
+        return self._err

--- a/sbol/test/__init__.py
+++ b/sbol/test/__init__.py
@@ -4,6 +4,7 @@ from .test_componentdefinition import TestComponentDefinitions
 from .test_constants import TestConstants
 from .test_design import TestDesign
 from .test_document import TestDocument
+from .test_error import TestError
 from .test_identified import TestIdentified
 from .test_config import TestConfig
 from .test_moduledefinition import TestModuleDefinition
@@ -26,6 +27,7 @@ def runTests(test_list=None):
             TestConstants,
             TestDesign,
             TestDocument,
+            TestError,
             TestIdentified,
             TestModuleDefinition,
             TestObject,

--- a/sbol/test/test_error.py
+++ b/sbol/test/test_error.py
@@ -1,0 +1,25 @@
+import unittest
+
+import sbol
+
+
+class TestError(unittest.TestCase):
+
+    def test_sbol_error_warning(self):
+        # There are lots of places where the SBOLError constructor is
+        # called with arguments in the wrong order. A warning has been
+        # added to note these occurrences until they can be fixed.
+        with self.assertWarns(RuntimeWarning):
+            sbol.SBOLError(sbol.SBOLErrorCode.NOT_FOUND_ERROR,
+                           'Item not found')
+
+    def test_what(self):
+        msg = 'Item not found'
+        error = sbol.SBOLError(msg, sbol.SBOLErrorCode.NOT_FOUND_ERROR)
+        self.assertEqual(error.what(), msg)
+
+    def test_error_code(self):
+        msg = 'Item not found'
+        code = sbol.SBOLErrorCode.NOT_FOUND_ERROR
+        error = sbol.SBOLError(msg, code)
+        self.assertEqual(error.error_code(), code)


### PR DESCRIPTION
Catch arguments out of order with a RuntimeWarning in the SBOLError constructor.

Add unit tests for SBOLError.

See #80 