### PR TITLE
Implement OwnedObject.find()

### DIFF
--- a/dev/hooks/pre-commit
+++ b/dev/hooks/pre-commit
@@ -14,7 +14,7 @@ EOF
 fi 
 
 # Run style checker
-MAX_VIOLATIONS=31
+MAX_VIOLATIONS=30
 echo "Checking style..."
 pycodestyle --exclude=./venv,./sbol/venv . > style.txt
 result=$(cat style.txt | wc -l)

--- a/sbol/document.py
+++ b/sbol/document.py
@@ -201,7 +201,7 @@ class Document(Identified):
         """
         # Check for uniqueness of URI
         if sbol_obj.identity in self.SBOLObjects:
-            raise SBOLError('Cannot add ' + sbol_obj.identity +
+            raise SBOLError('Cannot add ' + str(sbol_obj.identity) +
                             ' to Document. An object with this identity '
                             'is already contained in the Document',
                             SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)

--- a/sbol/test/test_property.py
+++ b/sbol/test/test_property.py
@@ -121,6 +121,23 @@ class TestProperty(unittest.TestCase):
         tp.value = expected
         self.assertEqual(tp.value, [])
 
-
-if __name__ == '__main__':
-    unittest.main()
+    def test_owned_object_find(self):
+        doc = sbol.Document()
+        md = doc.moduleDefinitions.create('foo')
+        # find() underlies __contains__ so test `in`
+        self.assertIn('foo', doc.moduleDefinitions)
+        self.assertNotIn('bar', doc.moduleDefinitions)
+        # find something that is in the collection
+        md2 = doc.moduleDefinitions.find('foo')
+        self.assertEqual(md, md2)
+        # find something that is not in the collection
+        with self.assertRaises(sbol.SBOLError):
+            doc.moduleDefinitions.find('bar')
+        # confirm we get the expected error code
+        try:
+            doc.moduleDefinitions.find('bar')
+        except sbol.SBOLError as err:
+            self.assertEqual(err.error_code(),
+                             sbol.SBOLErrorCode.NOT_FOUND_ERROR)
+        else:
+            self.fail('Expected SBOLError')


### PR DESCRIPTION
Add find for owned objects. Add unit test that also tests for `in`
because find supports the `__contains__` method.

Fixes #108 