### PR TITLE
Fix collection submissions

### DIFF
--- a/sbol/collection.py
+++ b/sbol/collection.py
@@ -5,8 +5,8 @@ from .property import URIProperty
 
 class Collection(TopLevel):
 
-    def __init__(self, type_uri=SBOL_COLLECTION,
-                 uri=URIRef("example"), version=VERSION_STRING):
+    def __init__(self, uri=URIRef("example"), version=VERSION_STRING,
+                 *, type_uri=SBOL_COLLECTION):
         super().__init__(type_uri, uri, version)
         self._members = URIProperty(self, SBOL_MEMBERS, '0', '*', [])
 

--- a/sbol/implementation.py
+++ b/sbol/implementation.py
@@ -5,8 +5,8 @@ from .property import URIProperty
 
 class Implementation(TopLevel):
 
-    def __init__(self, type_uri=SBOL_IMPLEMENTATION,
-                 uri=URIRef("example"), version=VERSION_STRING):
+    def __init__(self, uri=URIRef("example"), version=VERSION_STRING,
+                 *, type_uri=SBOL_IMPLEMENTATION):
         super().__init__(type_uri, uri, version)
         self._built = URIProperty(self, SBOL_URI+'#built', '0', '1', [])
 

--- a/sbol/partshop.py
+++ b/sbol/partshop.py
@@ -187,7 +187,7 @@ class PartShop:
         files['keywords'] = (None, keywords)
         files['overwrite_merge'] = (None, str(overwrite))
         files['user'] = (None, self.key)
-        files['file'] = (None, doc.writeString(), 'text/xml')
+        files['file'] = ('file', doc.writeString(), 'text/xml')
         if collection != '':
             files['rootCollections'] = (None, collection)
         # Send POST request

--- a/sbol/property.py
+++ b/sbol/property.py
@@ -284,13 +284,7 @@ class URIProperty(Property):
         else:
             if type(new_value_list) is list:
                 for value in new_value_list:
-                    if not isinstance(value, URIRef):
-                        self.logger.warning('Value "' + str(value) +
-                                            ' assigned to URIProperty ' +
-                                            ' is of type ' + str(type(value)) +
-                                            '. Wrapping it in: ' + str(URIRef))
-                        value = URIRef(value)
-                    self._sbol_owner.properties[self._rdf_type].append(value)
+                    self._sbol_owner.properties[self._rdf_type].append(URIRef(value))
             else:
                 # the list is actually not a list, but a single element, even
                 # though lists are supported.

--- a/sbol/test/__init__.py
+++ b/sbol/test/__init__.py
@@ -1,5 +1,6 @@
 import unittest
 import sys
+from .test_collection import TestCollection
 from .test_componentdefinition import TestComponentDefinitions
 from .test_constants import TestConstants
 from .test_design import TestDesign
@@ -24,6 +25,7 @@ from .test_validation import TestValidation
 def runTests(test_list=None):
     if test_list is None:
         test_list = [
+            TestCollection,
             TestComponentDefinitions,
             TestConfig,
             TestConstants,

--- a/sbol/test/test_collection.py
+++ b/sbol/test/test_collection.py
@@ -5,13 +5,13 @@ import rdflib
 import sbol
 
 
-class TestImplementation(unittest.TestCase):
+class TestCollection(unittest.TestCase):
 
     def __init__(self, *args):
         super().__init__(*args)
         self.homespace = 'http://example.org'
 
-    def make_identity(self, homespace, name, version, tipe='Implementation'):
+    def make_identity(self, homespace, name, version, tipe='Collection'):
         uri = '{}/{}/{}/{}'
         return uri.format(homespace, tipe, name, version)
 
@@ -21,64 +21,61 @@ class TestImplementation(unittest.TestCase):
         sbol.Config.setOption('sbol_typed_uris', True)
         sbol.Config.setOption('sbol_compliant_uris', True)
 
-    def test_implementation_exported(self):
-        self.assertIn('Implementation', dir(sbol))
-
     def testEmptyConstructor(self):
-        # This is the default name in the implementation constructor
+        # This is the default name in the collection constructor
         name = 'example'
-        c = sbol.Implementation()
+        c = sbol.Collection()
         expected_identity = self.make_identity(self.homespace, name,
                                                sbol.VERSION_STRING)
         self.assertEqual(c.identity, rdflib.URIRef(expected_identity))
         self.assertEqual(c.displayId, rdflib.Literal(name))
         self.assertEqual(c.version, rdflib.Literal(sbol.VERSION_STRING))
-        self.assertEqual(c.rdf_type, sbol.SBOL_IMPLEMENTATION)
+        self.assertEqual(c.rdf_type, sbol.SBOL_COLLECTION)
         doc = sbol.Document()
-        doc.addImplementation(c)
-        self.assertEqual(len(doc.implementations), 1)
+        doc.addCollection(c)
+        self.assertEqual(len(doc.collections), 1)
 
     def test1ArgConstructor(self):
         name = 'foo'
-        c = sbol.Implementation(name)
+        c = sbol.Collection(name)
         expected_identity = self.make_identity(self.homespace, name,
                                                sbol.VERSION_STRING)
         self.assertEqual(c.identity, rdflib.URIRef(expected_identity))
         self.assertEqual(c.displayId, rdflib.Literal(name))
         self.assertEqual(c.version, rdflib.Literal(sbol.VERSION_STRING))
-        self.assertEqual(c.rdf_type, sbol.SBOL_IMPLEMENTATION)
+        self.assertEqual(c.rdf_type, sbol.SBOL_COLLECTION)
         doc = sbol.Document()
-        doc.addImplementation(c)
-        self.assertEqual(len(doc.implementations), 1)
+        doc.addCollection(c)
+        self.assertEqual(len(doc.collections), 1)
 
     def test2ArgConstructor(self):
         name = 'foo'
         version = '3'
-        c = sbol.Implementation(name, version)
+        c = sbol.Collection(name, version)
         expected_identity = self.make_identity(self.homespace, name,
                                                version)
         self.assertEqual(c.identity, rdflib.URIRef(expected_identity))
         self.assertEqual(c.displayId, rdflib.Literal(name))
         self.assertEqual(c.version, rdflib.Literal(version))
-        self.assertEqual(c.rdf_type, sbol.SBOL_IMPLEMENTATION)
+        self.assertEqual(c.rdf_type, sbol.SBOL_COLLECTION)
         doc = sbol.Document()
-        doc.addImplementation(c)
-        self.assertEqual(len(doc.implementations), 1)
+        doc.addCollection(c)
+        self.assertEqual(len(doc.collections), 1)
 
     def test3ArgConstructor(self):
         name = 'foo'
         version = '3'
-        rdf_type = sbol.SBOL_IMPLEMENTATION + '2'
-        c = sbol.Implementation(name, version, type_uri=rdf_type)
+        rdf_type = sbol.SBOL_COLLECTION + '2'
+        c = sbol.Collection(name, version, type_uri=rdf_type)
         expected_identity = self.make_identity(self.homespace, name,
-                                               version, 'Implementation2')
+                                               version, 'Collection2')
         self.assertEqual(c.identity, rdflib.URIRef(expected_identity))
         self.assertEqual(c.displayId, rdflib.Literal(name))
         self.assertEqual(c.version, rdflib.Literal(version))
         self.assertEqual(c.rdf_type, rdf_type)
-        # Verify that when added to a document, this implementation is
-        # not in the list of implementations. That's because the rdf_type
-        # is not SBOL_IMPLEMENTATION.
+        # Verify that when added to a document, this collection is not
+        # in the list of collections. That's because the rdf_type is
+        # not SBOL_COLLECTION.
         doc = sbol.Document()
-        doc.addImplementation(c)
-        self.assertEqual(len(doc.implementations), 0)
+        doc.addCollection(c)
+        self.assertEqual(len(doc.collections), 0)


### PR DESCRIPTION
* Use 'file' instead of None for submitting the document via HTTP POST. This clears up some of the synbiohub_adapter submission tests that had been failing.
* Change some constructors so that the URI is the first argument, which is the most common backward compatible usage
  * Also move type_uri to be an optional keyword argument so that it is possible to override, but hard to override accidentally. See #113 for details

Fixes #57 
Fixes #113 