### PR TITLE
Add __bool__ methods to Document and Sequence

### DIFF
--- a/sbol/document.py
+++ b/sbol/document.py
@@ -700,6 +700,11 @@ class Document(Identified):
         """
         return self.size()
 
+    def __bool__(self):
+        # Ignore list semantics for boolean conversion.
+        # A document is True if it exists.
+        return True
+
     def __str__(self):
         """
         Produce a string representation of the Document.

--- a/sbol/sequence.py
+++ b/sbol/sequence.py
@@ -117,6 +117,11 @@ class Sequence(TopLevel):
         """
         return len(self.elements)
 
+    def __bool__(self):
+        # Ignore list semantics for boolean conversion.
+        # A sequence is True if it exists.
+        return True
+
     @deprecated(version='3.0.0', reason='Use len(sequence) instead')
     def length(self):
         """

--- a/sbol/test/test_document.py
+++ b/sbol/test/test_document.py
@@ -273,3 +273,7 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(doc.getImplementation(uri), impl)
         uri = rdflib.URIRef(uri_template.format(homespace, 'bar'))
         self.assertEqual(doc.getImplementation(uri), impl2)
+
+    def test_bool(self):
+        doc = sbol.Document()
+        self.assertTrue(doc)

--- a/sbol/test/test_sequence.py
+++ b/sbol/test/test_sequence.py
@@ -92,6 +92,6 @@ class TestSequence(unittest.TestCase):
         seq_read = doc2.sequences.get('CRP_b_seq').elements
         self.assertEqual(seq_read, seq)
 
-
-if __name__ == '__main__':
-    unittest.main()
+    def test_bool(self):
+        seq = sbol.Sequence()
+        self.assertTrue(seq)


### PR DESCRIPTION
Ignore list semantics for boolean conversion of Document and
Sequence. These classes are true by existing, as typical instances of
classes. The overriding of the __len__ method should not come into
play in determining the boolean conversion.

Fixes #79 
Fixes #112 
