### PR TITLE
Remove non-ascii characters

### DIFF
--- a/sbol/test/test_style.py
+++ b/sbol/test/test_style.py
@@ -10,6 +10,21 @@ SBOL_PATH = os.path.dirname(MODULE_LOCATION)
 # Please don't increase this number!
 MAX_WILDCARD_IMPORTS = 6
 
+# -----------------------------------------------------------------
+# Locale Fix
+#
+# If you get an ascii conversion error, you probably do not have a
+# local set.
+#
+# Follow these steps, substituting for "en_US.utf8" as appropriate:
+#
+#     apt update
+#     apt install locales
+#     locale-gen en_US.utf8
+#     export LANG=en_US.utf8
+#
+# -----------------------------------------------------------------
+
 
 class TestStyle(unittest.TestCase):
 

--- a/sbol/test/test_tutorial.py
+++ b/sbol/test/test_tutorial.py
@@ -26,7 +26,7 @@ class TestSbolTutorial(unittest.TestCase):
 
     @unittest.expectedFailure  # See Issue 24, Document has no attribute copy
     def test_tutorial(self):
-        # Set the default namespace (e.g. “http://my_namespace.org”)
+        # Set the default namespace (e.g. "http://my_namespace.org")
         namespace = "http://my_namespace.org"
         homespace = sbol.setHomespace(namespace)
 
@@ -60,7 +60,7 @@ class TestSbolTutorial(unittest.TestCase):
 
     @unittest.expectedFailure  # See Issue #25, PartShop has no attribute search
     def test_partshop(self):
-        # Start an interface to igem’s public part shop on
+        # Start an interface to igem's public part shop on
         # SynBioHub. Located at `https://synbiohub.org/public/igem`
         partshop = sbol.PartShop('https://synbiohub.org/public/igem')
 


### PR DESCRIPTION
Document how to configure locales in the case of non-ascii characters causing test_wildcard_imports to fail. Then remove the non-ascii characters from test_totorial.py

Fixes #117 