### PR TITLE
Fix #122 and add tests

### DIFF
--- a/sbol/property.py
+++ b/sbol/property.py
@@ -741,20 +741,27 @@ class ReferencedObject(Property):
         raise TypeError(errmsg.format(obj, type(obj)))
 
     def setSinglePropertyValue(self, new_value):
-        self._sbol_owner.properties[self._rdf_type] = [self._to_uri(new_value)]
+        if new_value is None: 
+            self._sbol_owner.properties[self._rdf_type] = []
+        else:
+            self._sbol_owner.properties[self._rdf_type] = [self._to_uri(new_value)]
 
     def setPropertyValueList(self, new_value):
-        if hasattr(new_value, '__uri__'):
-            # Convert to URI
-            # SBOLObjects have a __uri__ method, and others can too
-            new_value = new_value.__uri__()
-        if isinstance(new_value, str):
-            # Turn it into a list
-            new_value = [new_value]
-        if isinstance(new_value, collections.Iterable):
-            # Convert the items to URIRefs
-            new_value = list([self._to_uri(x) for x in new_value])
-        self._sbol_owner.properties[self._rdf_type] = new_value
+        if new_value is None: 
+            self._sbol_owner.properties[self._rdf_type] = []
+        else:
+            if hasattr(new_value, '__uri__'):
+                # Convert to URI
+                # SBOLObjects have a __uri__ method, and others can too
+                new_value = new_value.__uri__()
+            if isinstance(new_value, str):
+                # Turn it into a list
+                new_value = [new_value]
+            if isinstance(new_value, collections.Iterable):
+                # Convert the items to URIRefs
+                # Don't add None items to the list
+                new_value = list([self._to_uri(x) for x in new_value if x])
+            self._sbol_owner.properties[self._rdf_type] = new_value
 
     def add(self, uri):
         # Does anyone call this method? If so, it needs to be properly
@@ -780,6 +787,8 @@ class ReferencedObject(Property):
         a URIRef. The goal is to remove this method eventually.
 
         """
+        if thing is None:
+            return thing
         if isinstance(thing, rdflib.URIRef):
             return thing
         self.logger.warning('ReferencedObject was not a URIRef: {}'.format(thing))

--- a/sbol/property.py
+++ b/sbol/property.py
@@ -741,15 +741,13 @@ class ReferencedObject(Property):
         raise TypeError(errmsg.format(obj, type(obj)))
 
     def setSinglePropertyValue(self, new_value):
-        if new_value is None: 
-            self._sbol_owner.properties[self._rdf_type] = []
-        else:
+        if new_value:
             self._sbol_owner.properties[self._rdf_type] = [self._to_uri(new_value)]
+        else:
+            self._sbol_owner.properties[self._rdf_type] = []
 
     def setPropertyValueList(self, new_value):
-        if new_value is None: 
-            self._sbol_owner.properties[self._rdf_type] = []
-        else:
+        if new_value: 
             if hasattr(new_value, '__uri__'):
                 # Convert to URI
                 # SBOLObjects have a __uri__ method, and others can too
@@ -762,6 +760,9 @@ class ReferencedObject(Property):
                 # Don't add None items to the list
                 new_value = list([self._to_uri(x) for x in new_value if x])
             self._sbol_owner.properties[self._rdf_type] = new_value
+        else:
+            self._sbol_owner.properties[self._rdf_type] = []
+
 
     def add(self, uri):
         # Does anyone call this method? If so, it needs to be properly

--- a/sbol/property.py
+++ b/sbol/property.py
@@ -743,8 +743,8 @@ class ReferencedObject(Property):
     def setSinglePropertyValue(self, new_value):
         if new_value is None or new_value == '':
             self._sbol_owner.properties[self._rdf_type] = []
-        if new_value:
-            self._sbol_owner.properties[self._rdf_type] = [self._to_uri(new_value)]
+            return
+        self._sbol_owner.properties[self._rdf_type] = [self._to_uri(new_value)]
 
     def setPropertyValueList(self, new_value):
         if new_value is None:

--- a/sbol/test/test_property.py
+++ b/sbol/test/test_property.py
@@ -166,9 +166,10 @@ class TestProperty(unittest.TestCase):
         # Test conversion to URIRef
         c.definition = str(cd1.identity)
         self.assertEqual(type(c.definition), rdflib.URIRef)
-        
+
         cd0.sequences = [str(seq0a.identity), str(seq0b.identity)]
-        self.assertEqual([type(s) for s in cd0.sequences], [rdflib.URIRef, rdflib.URIRef])
+        self.assertEqual([type(s) for s in cd0.sequences],
+                         [rdflib.URIRef, rdflib.URIRef])
 
         # Test unset
         c.definition = None
@@ -180,7 +181,7 @@ class TestProperty(unittest.TestCase):
 
         cd0.sequences = []
         self.assertEqual(cd0.sequences, [])
-        
+
         cd0.sequences = [seq0a.identity, seq0b.identity]
         cd0.sequences = None
         self.assertEqual(cd0.sequences, [])

--- a/sbol/test/test_property.py
+++ b/sbol/test/test_property.py
@@ -141,3 +141,46 @@ class TestProperty(unittest.TestCase):
                              sbol.SBOLErrorCode.NOT_FOUND_ERROR)
         else:
             self.fail('Expected SBOLError')
+
+    def test_referenced_object(self):
+        # Test referenced object property is initialized to correct types
+        cd0 = sbol.ComponentDefinition('cd0')
+        self.assertEqual(type(cd0.sequences), list)
+
+        c = cd0.components.create('c')
+        self.assertEqual(c.definition, None)
+
+        # Test assignment
+        cd1 = sbol.ComponentDefinition('cd1')
+        c.definition = cd1.identity
+        self.assertEqual(c.definition, cd1.identity)
+
+        seq0a = sbol.Sequence('seq0a')
+        seq0b = sbol.Sequence('seq0b')
+        cd0.sequences = [seq0a.identity, seq0b.identity]
+        self.assertListEqual(cd0.sequences, [seq0a.identity, seq0b.identity])
+
+        c.definition = cd1
+        self.assertEqual(c.definition, cd1.identity)
+
+        # Test conversion to URIRef
+        c.definition = str(cd1.identity)
+        self.assertEqual(type(c.definition), rdflib.URIRef)
+        
+        cd0.sequences = [str(seq0a.identity), str(seq0b.identity)]
+        self.assertListEqual([type(s) for s in cd0.sequences], [rdflib.URIRef, rdflib.URIRef])
+
+        # Test unset
+        c.definition = None
+        self.assertEqual(c.definition, None)
+
+        cd0.sequences = []
+        self.assertEqual(cd0.sequences, [])
+        
+        cd0.sequences = [seq0a.identity, seq0b.identity]
+        cd0.sequences = None
+        self.assertEqual(cd0.sequences, [])
+
+        cd0.sequences = [seq0a.identity, seq0b.identity]
+        cd0.sequences = [None, None]
+        self.assertEqual(cd0.sequences, [])

--- a/sbol/test/test_property.py
+++ b/sbol/test/test_property.py
@@ -185,6 +185,7 @@ class TestProperty(unittest.TestCase):
         cd0.sequences = None
         self.assertEqual(cd0.sequences, [])
 
-        cd0.sequences = [seq0a.identity, seq0b.identity]
-        cd0.sequences = [None, None]
-        self.assertEqual(cd0.sequences, [])
+        with self.assertRaises(TypeError):
+            cd0.sequences = [seq0a.identity, seq0b.identity]
+            cd0.sequences = [None, None]
+            self.assertEqual(cd0.sequences, [])

--- a/sbol/test/test_property.py
+++ b/sbol/test/test_property.py
@@ -174,6 +174,10 @@ class TestProperty(unittest.TestCase):
         c.definition = None
         self.assertEqual(c.definition, None)
 
+        c.definition = cd1.identity
+        c.definition = ''
+        self.assertEqual(c.definition, None)
+
         cd0.sequences = []
         self.assertEqual(cd0.sequences, [])
         

--- a/sbol/test/test_property.py
+++ b/sbol/test/test_property.py
@@ -158,7 +158,7 @@ class TestProperty(unittest.TestCase):
         seq0a = sbol.Sequence('seq0a')
         seq0b = sbol.Sequence('seq0b')
         cd0.sequences = [seq0a.identity, seq0b.identity]
-        self.assertListEqual(cd0.sequences, [seq0a.identity, seq0b.identity])
+        self.assertEqual(cd0.sequences, [seq0a.identity, seq0b.identity])
 
         c.definition = cd1
         self.assertEqual(c.definition, cd1.identity)
@@ -168,7 +168,7 @@ class TestProperty(unittest.TestCase):
         self.assertEqual(type(c.definition), rdflib.URIRef)
         
         cd0.sequences = [str(seq0a.identity), str(seq0b.identity)]
-        self.assertListEqual([type(s) for s in cd0.sequences], [rdflib.URIRef, rdflib.URIRef])
+        self.assertEqual([type(s) for s in cd0.sequences], [rdflib.URIRef, rdflib.URIRef])
 
         # Test unset
         c.definition = None


### PR DESCRIPTION
- Fixed #122 -- ReferencedObject properties will not throw an error when trying to access them before they are initialized
- Also related to #93 -- ReferencedObject properties can be unset