### PR TITLE
Prevent overwriting owned objects through __setattr__

### DIFF
--- a/sbol/module.py
+++ b/sbol/module.py
@@ -6,8 +6,10 @@ from .property import OwnedObject, ReferencedObject
 
 
 class Module(Identified):
-    def __init__(self, rdf_type=SBOL_MODULE, uri='example',
-                 definition='', version=VERSION_STRING):
+    def __init__(self, uri='example',
+                 # Everything after the asterisk (`*`) is a keyword
+                 *, definition='', version=VERSION_STRING,
+                 rdf_type=SBOL_MODULE):
         super().__init__(rdf_type, uri, version)
         self.definition = ReferencedObject(self, SBOL_DEFINITION,
                                            SBOL_MODULE_DEFINITION,

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -6,6 +6,7 @@ import rdflib
 from .config import getHomespace
 from .config import hasHomespace
 from .constants import *
+from .property import OwnedObject
 from .property import ReferencedObject
 from .property import URIProperty
 from . import validation
@@ -400,6 +401,12 @@ class SBOLObject:
             result = result.value
         return result
 
+    def _is_owned_object(self, name):
+        try:
+            return isinstance(self.__dict__[name], OwnedObject)
+        except KeyError:
+            return False
+
     def _is_referenced_object(self, name):
         try:
             return isinstance(self.__dict__[name], ReferencedObject)
@@ -413,4 +420,6 @@ class SBOLObject:
         if self._is_referenced_object(name):
             self._set_referenced_object(name, value)
             return
+        if self._is_owned_object(name):
+            raise AttributeError('Cannot set owned object. Use set or add methods.')
         object.__setattr__(self, name, value)

--- a/sbol/property.py
+++ b/sbol/property.py
@@ -437,27 +437,31 @@ class OwnedObject(URIProperty):
         return obj
 
     def add(self, sbol_obj):
-        if self._sbol_owner is not None:
-            if sbol_obj.is_top_level() and self._sbol_owner.doc is not None:
-                self._sbol_owner.doc.add(sbol_obj)
-            else:
-                object_store = self._sbol_owner.owned_objects[self._rdf_type]
-                if sbol_obj in object_store:
-                    raise SBOLError("The object " + sbol_obj.identity +
-                                    " is already contained by the " +
-                                    self._rdf_type + " property",
-                                    SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
-                # Add to Document and check for uniqueness of URI
-                if self._sbol_owner.doc is not None:
-                    sbol_obj.doc = self._sbol_owner.doc
-                sbol_obj.parent = self._sbol_owner
-                # Update URI for the argument object and all its children,
-                # if SBOL-compliance is enabled.
-                sbol_obj.update_uri()
-                # Add to parent object
-                object_store.append(sbol_obj)
-                # Run validation rules
-                # TODO
+        if self._sbol_owner is None:
+            # Just silently do nothing?
+            return
+        if sbol_obj.is_top_level() and self._sbol_owner.doc is not None:
+            # Is this really all we need to do?
+            self._sbol_owner.doc.add(sbol_obj)
+            return
+        # Not top level, add to the attribute
+        object_store = self._sbol_owner.owned_objects[self._rdf_type]
+        if sbol_obj in object_store:
+            raise SBOLError("The object " + sbol_obj.identity +
+                            " is already contained by the " +
+                            self._rdf_type + " property",
+                            SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
+        # Add to Document and check for uniqueness of URI
+        if self._sbol_owner.doc is not None:
+            sbol_obj.doc = self._sbol_owner.doc
+        sbol_obj.parent = self._sbol_owner
+        # Update URI for the argument object and all its children,
+        # if SBOL-compliance is enabled.
+        sbol_obj.update_uri()
+        # Add to parent object
+        object_store.append(sbol_obj)
+        # Run validation rules
+        # TODO
 
     def __getitem__(self, id):
         if type(id) is int:

--- a/sbol/property.py
+++ b/sbol/property.py
@@ -215,7 +215,7 @@ class Property(ABC):
             return bool(obj)
 
     def _isHidden(self):
-        return self._rdf_type in self._sbol_owner.hidden_properties
+        return self._rdf_type in self._sbol_owner._hidden_properties
 
     def __len__(self):
         if self._rdf_type not in self._sbol_owner.properties:

--- a/sbol/property.py
+++ b/sbol/property.py
@@ -605,37 +605,34 @@ class OwnedObject(URIProperty):
         if new_value is not None:
             self.set(new_value)
 
-    def set(self, sbol_obj):
-        """Sets the first object in the container"""
-        if self._sbol_owner.is_top_level():
-            doc = self._sbol_owner.doc
-            if self._isHidden() and doc.find(sbol_obj.identity):
-                # In order to avoid a duplicate URI error, don't attempt
-                # to add the object if this is a hidden property,
-                pass
-            else:
-                doc.add(sbol_obj)
-        self.set_notoplevelcheck(sbol_obj)
-
-    def set_notoplevelcheck(self, sbol_obj):
-        # Add to parent object
-        if self._rdf_type not in self._sbol_owner.owned_objects:
-            self._sbol_owner.owned_objects[self._rdf_type] = []
-        if len(self._sbol_owner.owned_objects[self._rdf_type]) == 0:
-            self._sbol_owner.owned_objects[self._rdf_type].append(sbol_obj)
+    def set(self, new_value):
+        if self._sbol_owner is None:
+            # Not sure we should raise this, but I'm guessing it would
+            # be good to know.
+            # TODO: convert this to a better Python exception or to an
+            # SBOL exception
+            raise Exception('No owner for referenced value')
+        if self.getUpperBound() == '1':
+            self.setSinglePropertyValue(new_value)
         else:
-            raise SBOLError("Cannot set " + parsePropertyName(self._rdf_type) +
-                            " property. The property is already set. "
-                            "Call remove before attempting to "
-                            "overwrite the value.",
-                            SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
-        sbol_obj.parent = self._sbol_owner
-        # Update URI for the argument object and all its children,
-        # if SBOL-compliance is enabled.
-        sbol_obj.update_uri()
+            self.setPropertyValueList(new_value)
 
-        # Run validation rules
-        # TODO
+    def setSinglePropertyValue(self, new_value):
+        # Clear out the previous value, then add the new value
+        #
+        # TODO: This can leave the attribute empty if `add` fails.
+        # Can we capture that and sent the old value back again?
+        self._sbol_owner.owned_objects[self._rdf_type].clear()
+        self.add(new_value)
+
+    def setPropertyValueList(self, new_value):
+        # Clear out the previous value, then add the new value
+        #
+        # TODO: This can leave the attribute empty if `add` fails.
+        # Can we capture that and sent the old value back again?
+        self._sbol_owner.owned_objects[self._rdf_type].clear()
+        for nv in new_value:
+            self.add(nv)
 
     def remove(self, identifier):
         """id can be either an integer index or a string URI"""

--- a/sbol/test/test_ownedobject.py
+++ b/sbol/test/test_ownedobject.py
@@ -84,6 +84,28 @@ class TestOwnedObject(unittest.TestCase):
         m2 = md.modules[m.identity]
         self.assertEqual(m.identity, m2.identity)
 
+    def test_assignment(self):
+        doc = sbol.Document()
+        md = doc.moduleDefinitions.create('foo')
+        m1 = sbol.Module('m1')
+        m2 = sbol.Module('m2')
+        with self.assertRaises(AttributeError):
+            md.modules = [m1, m2]
 
-if __name__ == '__main__':
-    unittest.main()
+    def test_set_no_doc(self):
+        # Add a module when the parent module definition is not in a
+        # Document
+        md = sbol.ModuleDefinition('foo')
+        m1 = sbol.Module('m1')
+        md.modules.set([m1])
+        self.assertEqual(m1, md.modules.get(0))
+        self.assertEqual(m1, md.modules.find(m1.identity))
+
+    def test_find(self):
+        md = sbol.ModuleDefinition('foo')
+        m1 = md.modules.create('m1')
+        self.assertEqual(m1, md.modules.get(0))
+        self.assertEqual(m1, md.modules.find(m1.identity))
+        self.assertEqual(m1, md.modules.find(m1.displayId))
+        self.assertEqual(m1, md.modules.find(str(m1.displayId)))
+        self.assertEqual(m1, md.modules.find('m1'))


### PR DESCRIPTION
Prevent users from setting an OwnedObject attribute to a non-OwnedObject by catching it in `SBOLObject.__setattr__()`.

Fix up a few things that were broken with OwnedObjects:
* Fix isHidden to check the `_hidden_properties` attribute (_with_ an underscore prefix)
* Fix `OwnedObject.set()` to actually work instead of getting a series of exceptions in various cases, like if the sbol_owner is not in a document
* Simplify `OwnedObject.add()`so it isn't so deeply nested and the control flow is more obvious

Fixes #124 