### PR TITLE
Implement setPropertyValue

### DIFF
--- a/sbol/object.py
+++ b/sbol/object.py
@@ -255,7 +255,7 @@ class SBOLObject:
         :return: The value of the property or SBOL_ERROR_NOT_FOUND.
         """
         values = self.getPropertyValues(property_uri)
-        return str(values[0])
+        return values[0]
 
     def getPropertyValues(self, property_uri):
         """Get all values of a custom annotation property by its URI.

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -296,8 +296,8 @@ class SBOLObject:
             raise TypeError('%r is not a string', val)
         # Ensure that the property is a URIRef
         property_uri = rdflib.URIRef(property_uri)
-        # If there is effectively no value ('', None, [], {}, etc.)
-        # clear out the value
+        # If there is effectively no value (i.e. '') clear out the
+        # value
         if not val:
             # No value, no property, do nothing
             if property_uri not in self.properties:

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -306,7 +306,7 @@ class SBOLObject:
             # entry to the empty string. This is backward compatible
             # with pySBOL/libSBOL
             if self.properties[property_uri]:
-                self.properties[property_uri][0] = ''
+                self.properties[property_uri][0] = rdflib.Literal('')
             return
         # If the value does not exist, just set it and we're done
         if property_uri not in self.properties:

--- a/sbol/test/test_object.py
+++ b/sbol/test/test_object.py
@@ -61,3 +61,71 @@ class TestObject(unittest.TestCase):
         self.assertEqual(cd, cd2)
         with self.assertRaises(TypeError):
             cd.cast(sbol.ModuleDefinition)
+
+    def test_set_property_value_deprecated(self):
+        # Verify that setPropertyValue is deprecated
+        md = sbol.ModuleDefinition('md')
+        with warnings.catch_warnings(record=True) as warns:
+            md.setPropertyValue('myprop', 'foo')
+        self.assertEqual(len(warns), 1)
+
+    def test_set_property_value(self):
+        # Suppress the deprecation warnings
+        with warnings.catch_warnings(record=True) as warns:
+            self.deprecated_test_set_property_value()
+
+    def deprecated_test_set_property_value(self):
+        my_property = 'http://example.com/myproperty'
+        md = sbol.ModuleDefinition('md1')
+        # value argument must be of type string. If not, expect type error
+        with self.assertRaises(TypeError):
+            md.setPropertyValue(my_property, 2)
+        with self.assertRaises(TypeError):
+            md.setPropertyValue(my_property, ['foo', 'bar'])
+        # Test basic setting
+        foo_literal = rdflib.Literal('foo')
+        md.setPropertyValue(my_property, foo_literal)
+        self.assertEqual(md.getPropertyValue(my_property), foo_literal)
+        # Test overwriting a single existing value
+        bar_literal = rdflib.Literal('bar')
+        md.setPropertyValue(my_property, bar_literal)
+        self.assertEqual(md.getPropertyValue(my_property), bar_literal)
+        # Test setting an existing multi-value property
+        md.properties[rdflib.URIRef(my_property)] = [foo_literal, bar_literal]
+        self.assertEqual(md.getPropertyValue(my_property), foo_literal)
+        self.assertEqual(md.getPropertyValues(my_property), [foo_literal, bar_literal])
+        baz_literal = rdflib.Literal('baz')
+        md.setPropertyValue(my_property, baz_literal)
+        self.assertEqual(md.getPropertyValue(my_property), baz_literal)
+        self.assertEqual(md.getPropertyValues(my_property), [baz_literal, bar_literal])
+        # Unset the value
+        md.setPropertyValue(my_property, '')
+        self.assertEqual(md.getPropertyValue(my_property), '')
+        # This may seem odd, but it is the way pySBOL/libSBOL worked,
+        # so we do it for backward compatibility
+        self.assertEqual(md.getPropertyValues(my_property), ['', bar_literal])
+
+        # What about a plain string? Does that get converted to URIRef or Literal?
+        #  If a value is present, mimic that value's type
+        #  Else make the value a Literal
+        foo_str = 'foo'
+        bar_str = 'bar'
+        foo_uri = rdflib.URIRef(foo_str)
+        bar_uri = rdflib.URIRef(bar_str)
+        md2 = sbol.ModuleDefinition('md2')
+        # String gets converted to Literal
+        md2.setPropertyValue(my_property, foo_str)
+        self.assertEqual(md2.getPropertyValue(my_property), foo_literal)
+        # Ok to overwrite a Literal with a URIRef
+        md2.setPropertyValue(my_property, foo_uri)
+        self.assertEqual(md2.getPropertyValue(my_property), foo_uri)
+        # Now setting a str value should convert it to a URIRef
+        # because that's what is already there
+        md2.setPropertyValue(my_property, bar_str)
+        self.assertEqual(md2.getPropertyValue(my_property), bar_uri)
+        # Ok to overwrite a URIRef with a Literal
+        md2.setPropertyValue(my_property, foo_literal)
+        self.assertEqual(md2.getPropertyValue(my_property), foo_literal)
+        # Unsetting the value
+        md2.setPropertyValue(my_property, '')
+        self.assertEqual(md2.getPropertyValue(my_property), '')

--- a/sbol/test/test_object.py
+++ b/sbol/test/test_object.py
@@ -1,5 +1,8 @@
 import os
 import unittest
+import warnings
+
+import rdflib
 
 import sbol
 
@@ -21,7 +24,7 @@ class TestObject(unittest.TestCase):
         d = sbol.Document()
         d.read(PARTS_LOCATION)
         cd = d.componentDefinitions['http://examples.org/ComponentDefinition/AmeR/1']
-        expected = 'AmeR'
+        expected = rdflib.Literal('AmeR')
         name = cd.getPropertyValue(sbol.SBOL_NAME)
         self.assertEqual(name, expected)
 


### PR DESCRIPTION
pySBOL/libSBOL has recently deprecated `setPropertyValue` so deprecate it here as well.

Fixes #125 