### PR TITLE
130 range start and end

### DIFF
--- a/sbol/location.py
+++ b/sbol/location.py
@@ -52,7 +52,6 @@ class Range(Location):
     def end(self, val):
         self._end.set(val)
 
-
     def precedes(self, comparand):
         if self.end < comparand.start:
             return comparand.start - self.end

--- a/sbol/location.py
+++ b/sbol/location.py
@@ -33,8 +33,25 @@ class Range(Location):
     as is typical practice in computer science."""
     def __init__(self, uri=URIRef('example'), start=1, end=2, type_uri=SBOL_RANGE):
         super().__init__(uri=uri, type_uri=type_uri)
-        self.start = IntProperty(self, SBOL_START, '0', '1', None, start)
-        self.end = IntProperty(self, SBOL_END, '0', '1', None, end)
+        self._start = IntProperty(self, SBOL_START, '0', '1', None, start)
+        self._end = IntProperty(self, SBOL_END, '0', '1', None, end)
+
+    @property
+    def start(self):
+        return self._start.value
+
+    @start.setter
+    def start(self, val):
+        self._start.set(val)
+
+    @property
+    def end(self):
+        return self._end.value
+
+    @end.setter
+    def end(self, val):
+        self._end.set(val)
+
 
     def precedes(self, comparand):
         if self.end < comparand.start:

--- a/sbol/test/test_document.py
+++ b/sbol/test/test_document.py
@@ -289,3 +289,15 @@ class TestDocument(unittest.TestCase):
         cd = doc2.componentDefinitions['cd']
         cd.int_property = sbol.IntProperty(cd, 'http://examples.org', '0', '1', None)
         self.assertEqual(cd.int_property.value, 42)
+
+    def test_range(self):
+        # Test proper serializing and de-serializing of range properties
+        doc = sbol.Document()
+        cd = doc.componentDefinitions.create('cd')
+        sa = cd.sequenceAnnotations.create('sa')
+        r = sa.locations.createRange('r')
+        r.start = 42
+        doc2 = sbol.Document()
+        doc2.readString(doc.writeString())
+        r = doc2.componentDefinitions['cd'].sequenceAnnotations['sa'].locations['r']
+        self.assertEqual(r.start, 42)

--- a/sbol/test/test_property.py
+++ b/sbol/test/test_property.py
@@ -216,3 +216,5 @@ class TestProperty(unittest.TestCase):
         r.start = 42
         self.assertEqual(type(r.start), int)
         self.assertEqual(r.start, 42)
+        with self.assertRaises(TypeError):
+            r.start = 'forty-two'


### PR DESCRIPTION
- The previous PR related to issue #130 only tested with property values set directly through the IntProperty constructor, and did not test getters and setters
- Added getters and setters for the `end` and `start` properties
- Added tests for these