### PR TITLE
If a URIRef goes in, a URIRef comes out

### DIFF
--- a/sbol/identified.py
+++ b/sbol/identified.py
@@ -362,4 +362,7 @@ def replace_namespace(old_uri, target_namespace, rdf_type):
         # Map into a non-typed namespace
         replacement = getHomespace()
 
-    return old_uri.replace(replacement_target, replacement)
+    new_uri = old_uri.replace(replacement_target, replacement)
+    if type(old_uri) is URIRef:
+        return URIRef(new_uri)
+    return new_uri

--- a/sbol/location.py
+++ b/sbol/location.py
@@ -1,6 +1,6 @@
 from .identified import Identified
 from .constants import *
-from .property import IntProperty 
+from .property import IntProperty
 from .property import LiteralProperty
 from .property import OwnedObject
 from .property import ReferencedObject

--- a/sbol/test/test_identified.py
+++ b/sbol/test/test_identified.py
@@ -206,6 +206,21 @@ class TestCopy(unittest.TestCase):
         # Verify wasDerivedFrom relationship
         self.assertEqual(comp_copy.wasDerivedFrom[0], comp.identity)
 
+        # Ensure these are equal under the covers
+        self.assertEqual(type(comp.properties[sbol.SBOL_SEQUENCE_PROPERTY][0]),
+                         rdflib.URIRef)
+        self.assertEqual(type(comp.properties[sbol.SBOL_SEQUENCE_PROPERTY][0]),
+                         type(comp_copy.properties[sbol.SBOL_SEQUENCE_PROPERTY][0]))
+
+    def test_replace_namespace(self):
+        sbol.setHomespace('http://wallacecorporation.com')
+        old_namespace = 'http://tyrellcorporation.com'
+        old_uri = rdflib.URIRef(old_namespace + '/foo')
+        new_uri = sbol.identified.replace_namespace(old_uri, old_namespace,
+                                                    sbol.SBOL_COMPONENT_DEFINITION)
+        self.assertEqual(type(new_uri), rdflib.URIRef)
+        self.assertEqual(new_uri, rdflib.URIRef(sbol.getHomespace() + '/foo'))
+
     def test_import_into_nontyped_namespace_from_typed_namespace(self):
         # Copy an sbol-typed URI to a non-typed, sbol-compliant URI
         sbol.setHomespace('http://examples.org')


### PR DESCRIPTION
The `replace_namespace` method was demoting the URIRef input arguments to primitive strings. This ensures that if a URIRef goes in, a URIRef will come out the other end.

Fixes #133