### PR TITLE
24 document copy

### DIFF
--- a/sbol/document.py
+++ b/sbol/document.py
@@ -160,7 +160,6 @@ class Document(Identified):
         # super().__eq__ will have checked the types so we know other
         # is a Document at this point.
         if self._namespaces != other._namespaces:
-            print('Namespaces don\'t match')
             return False
         return True
 
@@ -819,3 +818,13 @@ class Document(Identified):
         msg = '{} is not a top level object'
         msg = msg.format(uri)
         raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+
+    def copy(self, target_doc=None, target_namespace=None, version=None):
+        # This enables the user to use the pattern doc2 = doc.copy() to clone a Document.
+        # SWIG pySBOL assumes the user does NOT want to increment the Document's version
+        # when creating a clone. (Whether or not these are the right semantics, that's
+        # how it is implemented.) By passing an explicit version parameter to super's
+        # copy method, we short-circuit its default behavior to auto-increment version.
+        if version is None:
+            version = self.version
+        return super().copy(target_doc, target_namespace, version)

--- a/sbol/document.py
+++ b/sbol/document.py
@@ -160,6 +160,7 @@ class Document(Identified):
         # super().__eq__ will have checked the types so we know other
         # is a Document at this point.
         if self._namespaces != other._namespaces:
+            print('Namespaces don\'t match')
             return False
         return True
 

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -242,10 +242,17 @@ class SBOLObject:
         if type(other) != type(self):
             return False
         if self.rdf_type != other.rdf_type:
+            print('RDF types don\'t match')
             return False
         if self.properties != other.properties:
+            print('Properties don\'t match')
+            for p1, p2 in zip(self.properties, other.properties):
+                for v1, v2 in zip(self.properties[p1], other.properties[p2]):
+                    print(v1, v2)
             return False
         if self.owned_objects != other.owned_objects:
+            print('Owned objects don\'t match')
+
             return False
         return True
 

--- a/sbol/object.py
+++ b/sbol/object.py
@@ -242,17 +242,10 @@ class SBOLObject:
         if type(other) != type(self):
             return False
         if self.rdf_type != other.rdf_type:
-            print('RDF types don\'t match')
             return False
         if self.properties != other.properties:
-            print('Properties don\'t match')
-            for p1, p2 in zip(self.properties, other.properties):
-                for v1, v2 in zip(self.properties[p1], other.properties[p2]):
-                    print(v1, v2)
             return False
         if self.owned_objects != other.owned_objects:
-            print('Owned objects don\'t match')
-
             return False
         return True
 

--- a/sbol/test/test_document.py
+++ b/sbol/test/test_document.py
@@ -301,3 +301,9 @@ class TestDocument(unittest.TestCase):
         doc2.readString(doc.writeString())
         r = doc2.componentDefinitions['cd'].sequenceAnnotations['sa'].locations['r']
         self.assertEqual(r.start, 42)
+
+    def test_copy(self):
+        doc = sbol.Document()
+        doc2 = doc.copy(version=rdflib.Literal('1'))
+        print(doc == doc2)
+        self.assertEqual(doc, doc2)

--- a/sbol/test/test_document.py
+++ b/sbol/test/test_document.py
@@ -302,8 +302,7 @@ class TestDocument(unittest.TestCase):
         r = doc2.componentDefinitions['cd'].sequenceAnnotations['sa'].locations['r']
         self.assertEqual(r.start, 42)
 
-    def test_copy(self):
+    def test_clone_document(self):
         doc = sbol.Document()
-        doc2 = doc.copy(version=rdflib.Literal('1'))
-        print(doc == doc2)
+        doc2 = doc.copy()
         self.assertEqual(doc, doc2)


### PR DESCRIPTION
- Implements and tests #24
- Implements a `Document.copy` method that overrides some of the behavior of the super's `copy` method
- The pattern `doc.copy()` outputs an exact clone of self