### PR TITLE
Fix OwnedLocation.createCut

### DIFF
--- a/sbol/location.py
+++ b/sbol/location.py
@@ -103,7 +103,7 @@ class Cut(Location):
     two coordinates of a Sequence's elements."""
     def __init__(self, uri=URIRef('example'), at=1, type_uri=SBOL_CUT):
         super().__init__(uri=uri, type_uri=type_uri)
-        self._at = LiteralProperty(self, SBOL_AT, '1', '1', [], at)
+        self._at = IntProperty(self, SBOL_AT, '1', '1', [], at)
 
     @property
     def at(self):

--- a/sbol/test/test_componentdefinition.py
+++ b/sbol/test/test_componentdefinition.py
@@ -178,10 +178,7 @@ class TestComponentDefinitions(unittest.TestCase):
         self.assertEqual(type(gl), sbol.GenericLocation)
         self.assertEqual(len(sa.locations), 2)
 
-    @unittest.expectedFailure
     def testCut(self):
-        # This test is marked as expectedFailure for now, but can probably
-        # be merged with testOwnedLocation when it is passing
         cd = sbol.ComponentDefinition('cd')
         sa = cd.sequenceAnnotations.create('sa')
         c = sa.locations.createCut('c')


### PR DESCRIPTION
Changed `at` from `LiteralProperty` to `IntProperty`.

Fixes #142 